### PR TITLE
Improve Home Screen API Performance using Redis Cache

### DIFF
--- a/API-Server/build.gradle
+++ b/API-Server/build.gradle
@@ -52,6 +52,10 @@ dependencies {
 
     // sentry
     implementation 'io.sentry:sentry-spring-boot-starter-jakarta:6.25.0'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    testImplementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
 }
 
 tasks.named('test') {

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/global/cache/CacheKey.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/global/cache/CacheKey.java
@@ -1,18 +1,16 @@
 package swm.hkcc.LGTM.app.global.cache;
 
 import lombok.RequiredArgsConstructor;
+import static swm.hkcc.LGTM.app.global.cache.TTLKey.*;
 
 @RequiredArgsConstructor
 public enum CacheKey {
-    PERMANENT("permanent", 0),
-    ONE_MONTH("one_month", 60 * 60 * 24 * 30),
-    ONE_WEEK("one_week", 60 * 60 * 24 * 7),
-    ONE_DAY("one_day", 60 * 60 * 24),
-    FIVE_HOUR("five_hour", 60 * 60 * 5),
-    ONE_HOUR("one_hour", 60 * 60),
-    TEN_MIN("ten_min", 60 * 10),
-    FIVE_MIN("five_min", 60 * 5),
-    ONE_MIN("one_min", 60 * 1)
+    TECH_TAG("tech_tag", ONE_MONTH.getExpiryTimeSec()),
+    TECH_TAG_EXISTS("tech_tag_exists", ONE_MONTH.getExpiryTimeSec()),
+    TECH_TAG_PER_MEMBER("tech_tag_per_member", ONE_DAY.getExpiryTimeSec()),
+    TECH_TAG_PER_MISSION("tech_tag_per_mission", ONE_DAY.getExpiryTimeSec()),
+    MISSION_PARTICIPANT_COUNT("mission_participant_count", ONE_DAY.getExpiryTimeSec()),
+
     ;
 
     private final String key;
@@ -25,4 +23,5 @@ public enum CacheKey {
     public int getExpiryTimeSec() {
         return expiryTimeSec;
     }
+
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/global/cache/CacheKey.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/global/cache/CacheKey.java
@@ -4,9 +4,16 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum CacheKey {
-    LONG("long", 60 * 60),
-    SHORT("short", 60 * 1),
-    MEDIUM("medium", 60 * 5);
+    PERMANENT("permanent", 0),
+    ONE_MONTH("one_month", 60 * 60 * 24 * 30),
+    ONE_WEEK("one_week", 60 * 60 * 24 * 7),
+    ONE_DAY("one_day", 60 * 60 * 24),
+    FIVE_HOUR("five_hour", 60 * 60 * 5),
+    ONE_HOUR("one_hour", 60 * 60),
+    TEN_MIN("ten_min", 60 * 10),
+    FIVE_MIN("five_min", 60 * 5),
+    ONE_MIN("one_min", 60 * 1)
+    ;
 
     private final String key;
     private final int expiryTimeSec;

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/global/cache/CacheKey.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/global/cache/CacheKey.java
@@ -1,0 +1,21 @@
+package swm.hkcc.LGTM.app.global.cache;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum CacheKey {
+    LONG("long", 60 * 60),
+    SHORT("short", 60 * 1),
+    MEDIUM("medium", 60 * 5);
+
+    private final String key;
+    private final int expiryTimeSec;
+
+    public String getKey() {
+        return key;
+    }
+
+    public int getExpiryTimeSec() {
+        return expiryTimeSec;
+    }
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/global/cache/CacheKey.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/global/cache/CacheKey.java
@@ -10,7 +10,11 @@ public enum CacheKey {
     TECH_TAG_PER_MEMBER("tech_tag_per_member", ONE_DAY.getExpiryTimeSec()),
     TECH_TAG_PER_MISSION("tech_tag_per_mission", ONE_DAY.getExpiryTimeSec()),
     MISSION_PARTICIPANT_COUNT("mission_participant_count", ONE_DAY.getExpiryTimeSec()),
-
+    ON_GOING_MISSIONS("on_going_missions", ONE_MIN.getExpiryTimeSec()),
+    RECOMMENDED_MISSIONS("recommended_missions", ONE_MIN.getExpiryTimeSec()),
+    TOTAL_MISSIONS("total_missions", ONE_MIN.getExpiryTimeSec()),
+    MISSION_SCRAP_COUNT("mission_scrap_count", ONE_MIN.getExpiryTimeSec()),
+    MISSION_VIEW_COUNT("mission_view_count", ONE_MIN.getExpiryTimeSec()),
     ;
 
     private final String key;

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/global/cache/TTLKey.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/global/cache/TTLKey.java
@@ -1,0 +1,23 @@
+package swm.hkcc.LGTM.app.global.cache;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum TTLKey {
+    PERMANENT(60 * 60 * 24 * 365),
+    ONE_MONTH(60 * 60 * 24 * 30),
+    ONE_WEEK(60 * 60 * 24 * 7),
+    ONE_DAY(60 * 60 * 24),
+    FIVE_HOUR(60 * 60 * 5),
+    ONE_HOUR(60 * 60),
+    TEN_MIN(60 * 10),
+    FIVE_MIN(60 * 5),
+    ONE_MIN(60 * 1)
+    ;
+
+    private final int expiryTimeSec;
+
+    public int getExpiryTimeSec() {
+        return expiryTimeSec;
+    }
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/member/domain/Authority.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/member/domain/Authority.java
@@ -2,17 +2,17 @@ package swm.hkcc.LGTM.app.modules.member.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.io.Serializable;
 
 @Entity
 @Getter
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class Authority {
+public class Authority implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/member/domain/Junior.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/member/domain/Junior.java
@@ -4,13 +4,15 @@ import jakarta.persistence.*;
 import lombok.*;
 import swm.hkcc.LGTM.app.modules.auth.dto.signUp.JuniorSignUpRequest;
 
+import java.io.Serializable;
+
 @Entity
 @Getter
 @ToString
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class Junior {
+public class Junior implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/member/domain/Member.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/member/domain/Member.java
@@ -5,16 +5,17 @@ import lombok.*;
 import swm.hkcc.LGTM.app.global.entity.BaseEntity;
 import swm.hkcc.LGTM.app.modules.auth.dto.signUp.CommonUserData;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@ToString
 @Builder
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class Member extends BaseEntity {
+public class Member extends BaseEntity implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,7 +34,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String refreshToken;
 
-    @Column(unique = true)
+    @Column(nullable = false)
     private String deviceToken;
 
     @Column(nullable = false)
@@ -48,7 +49,7 @@ public class Member extends BaseEntity {
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
     private Senior senior;
 
-    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     @Builder.Default
     private List<Authority> roles = new ArrayList<>();
 

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/member/domain/Senior.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/member/domain/Senior.java
@@ -6,13 +6,15 @@ import lombok.*;
 import swm.hkcc.LGTM.app.modules.auth.dto.signUp.SeniorSignUpRequest;
 import swm.hkcc.LGTM.app.modules.member.exception.InvalidCareerPeriod;
 
+import java.io.Serializable;
+
 @Entity
 @Getter
 @ToString
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class Senior {
+public class Senior implements Serializable {
 
     private static final Integer MINIMUM_CAREER_PERIOD = 12;
 

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/domain/Mission.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/domain/Mission.java
@@ -5,15 +5,16 @@ import lombok.*;
 import swm.hkcc.LGTM.app.global.entity.BaseEntity;
 import swm.hkcc.LGTM.app.modules.member.domain.Member;
 
+import java.io.Serializable;
 import java.time.LocalDate;
 
 @Entity
 @Getter
 @Builder
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString
-public class Mission extends BaseEntity {
+public class Mission extends BaseEntity implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "mission_id")

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionCustomRepository.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionCustomRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 public interface MissionCustomRepository {
     List<Mission> getOnGoingMissions(Long memberId);
 
-    List<Mission> getRecommendedMissions(Long memberId);
+    List<Mission> getRecommendedMissions();
 
-    List<Mission> getTotalMissions(Long memberId);
+    List<Mission> getTotalMissions();
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionCustomRepositoryImpl.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionCustomRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
 import swm.hkcc.LGTM.app.modules.mission.domain.MissionStatus;
@@ -23,16 +24,19 @@ public class MissionCustomRepositoryImpl implements MissionCustomRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
+    @Cacheable(value = "on_going_missions", key = "#memberId")
     public List<Mission> getOnGoingMissions(Long memberId) {
         return getMissions(isMemberParticipating(memberId), isNotCompleted());
     }
 
     @Override // todo: get recommended missions
+    @Cacheable(value = "recommended_missions", key = "#memberId")
     public List<Mission> getRecommendedMissions(Long memberId) {
         return null;
     }
 
     @Override
+    @Cacheable(value = "total_missions", key = "#memberId")
     public List<Mission> getTotalMissions(Long memberId) {
         return getMissions(isMissionNotFinished());
     }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionCustomRepositoryImpl.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionCustomRepositoryImpl.java
@@ -30,14 +30,13 @@ public class MissionCustomRepositoryImpl implements MissionCustomRepository {
     }
 
     @Override // todo: get recommended missions
-    @Cacheable(value = "recommended_missions", key = "#memberId")
-    public List<Mission> getRecommendedMissions(Long memberId) {
+    public List<Mission> getRecommendedMissions () {
         return null;
     }
 
     @Override
-    @Cacheable(value = "total_missions", key = "#memberId")
-    public List<Mission> getTotalMissions(Long memberId) {
+    @Cacheable(value = "total_missions")
+    public List<Mission> getTotalMissions() {
         return getMissions(isMissionNotFinished());
     }
 

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionScrapRepository.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionScrapRepository.java
@@ -1,9 +1,11 @@
 package swm.hkcc.LGTM.app.modules.mission.repository;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import swm.hkcc.LGTM.app.modules.mission.domain.MissionScrap;
 
 public interface MissionScrapRepository extends JpaRepository<MissionScrap, Long> {
+    @Cacheable(value = "mission_scrap_count", key = "#missionId")
     int countByMission_MissionId(Long missionId);
     boolean existsByScrapper_MemberIdAndMission_MissionId(Long memberId, Long missionId);
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionViewRepository.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionViewRepository.java
@@ -1,8 +1,10 @@
 package swm.hkcc.LGTM.app.modules.mission.repository;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import swm.hkcc.LGTM.app.modules.mission.domain.MissionView;
 
 public interface MissionViewRepository extends JpaRepository<MissionView, Long> {
+    @Cacheable(value = "mission_view_count", key = "#missionId")
     int countByMission_MissionId(Long missionId);
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/service/MissionServiceImpl.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/service/MissionServiceImpl.java
@@ -10,7 +10,7 @@ import swm.hkcc.LGTM.app.modules.mission.dto.MissionDto;
 import swm.hkcc.LGTM.app.modules.mission.repository.MissionRepository;
 import swm.hkcc.LGTM.app.modules.mission.repository.MissionScrapRepository;
 import swm.hkcc.LGTM.app.modules.mission.repository.MissionViewRepository;
-import swm.hkcc.LGTM.app.modules.registration.domain.repository.MissionRegistrationRepository;
+import swm.hkcc.LGTM.app.modules.registration.repository.MissionRegistrationRepository;
 import swm.hkcc.LGTM.app.modules.tag.domain.TechTag;
 import swm.hkcc.LGTM.app.modules.tag.repository.TechTagPerMissionRepository;
 

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/service/MissionServiceImpl.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/service/MissionServiceImpl.java
@@ -42,7 +42,7 @@ public class MissionServiceImpl implements MissionService {
 
     @Override // todo: 추천 미션 가져오기 구현 미완료 -> 전체 미션 가져오기로 임시 대체
     public MissionContentData getRecommendMissions(Long memberId) {
-        List<Mission> missions = missionRepository.getTotalMissions(memberId);
+        List<Mission> missions = missionRepository.getTotalMissions();
 
         return MissionContentData.of(
                 missions.stream()
@@ -53,7 +53,7 @@ public class MissionServiceImpl implements MissionService {
 
     @Override
     public MissionContentData getTotalMissions(Long memberId) {
-        List<Mission> missions = missionRepository.getTotalMissions(memberId);
+        List<Mission> missions = missionRepository.getTotalMissions();
 
         return MissionContentData.of(
                 missions.stream()

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/domain/MissionRegistration.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/domain/MissionRegistration.java
@@ -6,12 +6,15 @@ import swm.hkcc.LGTM.app.global.entity.BaseEntity;
 import swm.hkcc.LGTM.app.modules.member.domain.Member;
 import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
 
+import java.io.Serializable;
+
 @Entity
 @Getter
 @Builder
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MissionRegistration extends BaseEntity {
+public class MissionRegistration extends BaseEntity implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionRegistrationRepository.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionRegistrationRepository.java
@@ -1,8 +1,10 @@
 package swm.hkcc.LGTM.app.modules.registration.repository;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import swm.hkcc.LGTM.app.modules.registration.domain.MissionRegistration;
 
 public interface MissionRegistrationRepository extends JpaRepository<MissionRegistration, Long> {
+    @Cacheable(value = "mission_participant_count", key = "#missionId")
     int countByMission_MissionId(Long missionId);
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionRegistrationRepository.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionRegistrationRepository.java
@@ -1,4 +1,4 @@
-package swm.hkcc.LGTM.app.modules.registration.domain.repository;
+package swm.hkcc.LGTM.app.modules.registration.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import swm.hkcc.LGTM.app.modules.registration.domain.MissionRegistration;

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/tag/domain/TechTag.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/tag/domain/TechTag.java
@@ -2,14 +2,16 @@ package swm.hkcc.LGTM.app.modules.tag.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import swm.hkcc.LGTM.app.global.entity.BaseEntity;
+
+import java.io.Serializable;
 
 @Entity
 @Getter
 @Builder
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TechTag {
+public class TechTag implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/tag/repository/TechTagPerMissionRepository.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/tag/repository/TechTagPerMissionRepository.java
@@ -1,5 +1,6 @@
 package swm.hkcc.LGTM.app.modules.tag.repository;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +10,7 @@ import swm.hkcc.LGTM.app.modules.tag.domain.TechTagPerMission;
 import java.util.List;
 
 public interface TechTagPerMissionRepository extends JpaRepository<TechTagPerMission, Long> {
+    @Cacheable(value = "tech_tag_per_mission", key = "#missionId")
     @Query("select tpm.techTag from TechTagPerMission tpm where tpm.mission.missionId = :missionId")
     List<TechTag> findTechTagsByMissionId(@Param("missionId") Long missionId);
 

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/tag/repository/TechTagRepository.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/tag/repository/TechTagRepository.java
@@ -1,6 +1,7 @@
 package swm.hkcc.LGTM.app.modules.tag.repository;
 
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import swm.hkcc.LGTM.app.modules.tag.domain.TechTag;
@@ -9,7 +10,9 @@ import java.util.Optional;
 
 @Repository
 public interface TechTagRepository extends JpaRepository<TechTag, Long> {
+    @Cacheable(value = "tech_tag", key = "#name")
     Optional<TechTag> findByName(String name);
 
+    @Cacheable(value = "tech_tag_exist", key = "#name")
     boolean existsByName(String name);
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/config/RedisConfig.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/config/RedisConfig.java
@@ -1,0 +1,78 @@
+package swm.hkcc.LGTM.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import swm.hkcc.LGTM.app.global.cache.CacheKey;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Configuration
+@EnableCaching
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+    @Bean
+    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory){
+        RedisCacheConfiguration defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .disableCachingNullValues()
+                .computePrefixWith(CacheKeyPrefix.simple())
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair
+                                .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair
+                                .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        Map<String, RedisCacheConfiguration> cacheConfigurations = Arrays.stream(CacheKey.values())
+                .collect(Collectors.toMap(
+                        CacheKey::getKey,
+                        cacheKey -> RedisCacheConfiguration.defaultCacheConfig()
+                                .entryTtl(Duration.ofSeconds(cacheKey.getExpiryTimeSec()))
+                ));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(defaultCacheConfig)
+                .withInitialCacheConfigurations(cacheConfigurations)
+                .build();
+    }
+}
+

--- a/API-Server/src/main/resources/application-dev.yml
+++ b/API-Server/src/main/resources/application-dev.yml
@@ -22,3 +22,8 @@ spring:
     sql:
       init:
         mode: always
+
+  data:
+    redis:
+      host: ${DEV_REDIS_HOST}
+      port: ${DEV_REDIS_PORT}

--- a/API-Server/src/main/resources/application-prod.yml
+++ b/API-Server/src/main/resources/application-prod.yml
@@ -22,3 +22,8 @@ spring:
     sql:
       init:
         mode: never
+
+  data:
+    redis:
+      host: ${PROD_REDIS_HOST}
+      port: ${PROD_REDIS_PORT}

--- a/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionCustomRepositoryImplTest.java
+++ b/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionCustomRepositoryImplTest.java
@@ -5,9 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import swm.hkcc.LGTM.app.modules.member.domain.Member;
@@ -16,7 +14,7 @@ import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
 import swm.hkcc.LGTM.app.modules.mission.domain.MissionStatus;
 import swm.hkcc.LGTM.app.modules.registration.domain.MissionRegistration;
 import swm.hkcc.LGTM.app.modules.registration.domain.PersonalStatus;
-import swm.hkcc.LGTM.app.modules.registration.domain.repository.MissionRegistrationRepository;
+import swm.hkcc.LGTM.app.modules.registration.repository.MissionRegistrationRepository;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionCustomRepositoryImplTest.java
+++ b/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionCustomRepositoryImplTest.java
@@ -150,7 +150,7 @@ class MissionCustomRepositoryImplTest {
         Long memberId = member.getMemberId();
 
         // When
-        List<Mission> totalMissions = missionRepository.getTotalMissions(memberId);
+        List<Mission> totalMissions = missionRepository.getTotalMissions();
 
         // Then
         assertThat(totalMissions).isNotNull();

--- a/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/mission/service/MissionServiceImplTest.java
+++ b/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/mission/service/MissionServiceImplTest.java
@@ -13,7 +13,7 @@ import swm.hkcc.LGTM.app.modules.mission.domain.MissionStatus;
 import swm.hkcc.LGTM.app.modules.mission.dto.MissionDetailsDto;
 import swm.hkcc.LGTM.app.modules.mission.dto.MissionDto;
 import swm.hkcc.LGTM.app.modules.mission.repository.*;
-import swm.hkcc.LGTM.app.modules.registration.domain.repository.MissionRegistrationRepository;
+import swm.hkcc.LGTM.app.modules.registration.repository.MissionRegistrationRepository;
 import swm.hkcc.LGTM.app.modules.tag.repository.TechTagPerMissionRepository;
 
 import java.time.LocalDate;

--- a/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/mission/service/MissionServiceImplTest.java
+++ b/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/mission/service/MissionServiceImplTest.java
@@ -67,7 +67,7 @@ public class MissionServiceImplTest {
     @DisplayName("맞춤 추천 미션을 가져온다. MissionDetailDto의 리스트를 담은 MissionContentData를 반환한다.")
     public void getRecommendMissions() {
         // Given
-        when(missionRepository.getTotalMissions(1L))
+        when(missionRepository.getTotalMissions())
                 .thenReturn(Arrays.asList(createMockMission(1L), createMockMission(2L), createMockMission(3L)));
 
         // When
@@ -86,7 +86,7 @@ public class MissionServiceImplTest {
     @DisplayName("전체 미션을 가져온다. MissionDetailDto의 리스트를 담은 MissionContentData를 반환한다.")
     public void getTotalMissions() {
         // Given
-        when(missionRepository.getTotalMissions(1L))
+        when(missionRepository.getTotalMissions())
                 .thenReturn(Arrays.asList(createMockMission(1L), createMockMission(2L)));
 
         // When

--- a/API-Server/src/test/java/swm/hkcc/LGTM/config/EmbeddedRedisConfig.java
+++ b/API-Server/src/test/java/swm/hkcc/LGTM/config/EmbeddedRedisConfig.java
@@ -1,0 +1,98 @@
+package swm.hkcc.LGTM.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.util.StringUtils;
+import redis.embedded.RedisServer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+@TestConfiguration
+public class EmbeddedRedisConfig {
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    private RedisServer redisServer;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @PostConstruct
+    public void redisServer() throws IOException {
+        int port = isRedisRunning() ? findAvailablePort() : this.port;
+        redisServer = new RedisServer(port);
+        System.out.println("port = " + port);
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+
+    /**
+     * Embedded Redis가 현재 실행중인지 확인
+     */
+    private boolean isRedisRunning() throws IOException {
+        return isRunning(executeGrepProcessCommand(port));
+    }
+
+    /**
+     * 현재 PC/서버에서 사용가능한 포트 조회
+     */
+    public int findAvailablePort() throws IOException {
+
+        for (int port = 10000; port <= 65535; port++) {
+            Process process = executeGrepProcessCommand(port);
+            if (!isRunning(process)) {
+                return port;
+            }
+        }
+
+        throw new IllegalArgumentException("Not Found Available port: 10000 ~ 65535");
+    }
+
+    /**
+     * 해당 port를 사용중인 프로세스 확인하는 sh 실행
+     */
+    private Process executeGrepProcessCommand(int port) throws IOException {
+        String command = String.format("netstat -nat | grep LISTEN|grep %d", port);
+        String[] shell = {"/bin/sh", "-c", command};
+        return Runtime.getRuntime().exec(shell);
+    }
+
+    /**
+     * 해당 Process가 현재 실행중인지 확인
+     */
+    private boolean isRunning(Process process) {
+        String line;
+        StringBuilder pidInfo = new StringBuilder();
+
+        try (BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+
+            while ((line = input.readLine()) != null) {
+                pidInfo.append(line);
+            }
+
+        } catch (Exception e) {
+        }
+
+        return !StringUtils.isEmpty(pidInfo.toString());
+    }
+}
+

--- a/API-Server/src/test/java/swm/hkcc/LGTM/config/RedisConfigTest.java
+++ b/API-Server/src/test/java/swm/hkcc/LGTM/config/RedisConfigTest.java
@@ -1,0 +1,67 @@
+package swm.hkcc.LGTM.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataRedisTest
+@Import(EmbeddedRedisConfig.class)
+@ActiveProfiles("test")
+class RedisConfigTest {
+
+    @Autowired
+    StringRedisTemplate stringRedisTemplate;
+
+    @Test
+    public void testStrings() {
+        final String key = "stringKey";
+        final ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+
+        valueOperations.set(key, "value1");
+        final String result1 = valueOperations.get(key);
+
+        assertEquals("value1", result1);
+    }
+
+    @Test
+    public void testList() {
+        final String key = "listKey";
+        final ListOperations<String, String> listOperations = stringRedisTemplate.opsForList();
+
+        listOperations.rightPush(key, "value1");
+        listOperations.rightPush(key, "value2");
+        listOperations.rightPush(key, "value3");
+
+        final String char1 = listOperations.index(key, 0);
+        final String char2 = listOperations.index(key, 1);
+        final String char3 = listOperations.index(key, 2);
+
+        assertEquals("value1", char1);
+        assertEquals("value2", char2);
+        assertEquals("value3", char3);
+    }
+
+    @Test
+    public void testHash() {
+        final String key = "chanho";
+        final HashOperations<String, Object, Object> hashOperations = stringRedisTemplate.opsForHash();
+
+        hashOperations.put(key, "name", "chanho");
+        hashOperations.put(key, "age", "23");
+        hashOperations.put(key, "job", "developer");
+
+        assertThat(hashOperations.get(key, "name")).isEqualTo("chanho");
+        assertThat(hashOperations.get(key, "age")).isEqualTo("23");
+        assertThat(hashOperations.get(key, "job")).isEqualTo("developer");
+    }
+
+}


### PR DESCRIPTION
## 📝요약
- 홈화면 API 성능을 개선하기 위해 Redis 캐시를 도입했습니다.
- API 응답 시간은 1727ms에서 285ms로 개선되었습니다. (완벽한 분석은 아니지만, API 응답 시간을 측정한 결과입니다.)

## 🔥작업 내용 
- Redis 설정: Redis 연결 및 캐시 관리를 위한 설정을 추가했습니다.
- @Cachable 사용 : 홈화면 api를 구성하는 여러 repository의 메소드들에 redis cache를 적용하였습니다. 캐시 Hit 율이 높을 것으로 예상되는 쿼리에 대해서만 캐시를 적용하였습니다.

## 📋참고 사항
- cache로 응답 속도를 개선한 만큼 여러 trade off를 고려하여 캐시 적용 범위를 조절해야 될 것 같습니다.
- cache Hit rate를 분석하여 Hit rate가 낮은 부분은 cache 적용 코드를 제거할 예정입니다.
완벽한 성능 분석은 아니지만, API Response 응답 시간이 매우 빨라졌음을 확인하였습니다.

캐싱 적용 전 : 1727ms
<img width="1105" alt="스크린샷 2023-08-08 오후 3 55 47" src="https://github.com/hellokitty-coding-club/LGTM-Backend/assets/83508073/ec22ca52-e17e-45f2-a994-fcbef2528feb">

캐싱 적용 후 : 285ms
<img width="1106" alt="스크린샷 2023-08-08 오후 3 58 13" src="https://github.com/hellokitty-coding-club/LGTM-Backend/assets/83508073/60129dfc-5c90-4f97-8d93-74f333ac816b">


## 🎯관련 이슈

- Close #31 

