### PR TITLE
Redis Cluster with AWS Elastic Cache

### DIFF
--- a/API-Server/src/main/java/swm/hkcc/LGTM/config/RedisClusterConfig.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/config/RedisClusterConfig.java
@@ -1,0 +1,79 @@
+package swm.hkcc.LGTM.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import swm.hkcc.LGTM.app.global.cache.CacheKey;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Configuration
+@EnableCaching
+@EnableRedisRepositories
+@Profile({"prod", "dev"})
+public class RedisClusterConfig {
+
+    @Value("${spring.data.redis.cluster.nodes}")
+    private List<String> clusterNodes;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisClusterConfiguration clusterConfiguration = new RedisClusterConfiguration(clusterNodes);
+        return new LettuceConnectionFactory(clusterConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+    @Bean
+    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .disableCachingNullValues()
+                .computePrefixWith(CacheKeyPrefix.simple())
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair
+                                .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair
+                                .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        Map<String, RedisCacheConfiguration> cacheConfigurations = Arrays.stream(CacheKey.values())
+                .collect(Collectors.toMap(
+                        CacheKey::getKey,
+                        cacheKey -> RedisCacheConfiguration.defaultCacheConfig()
+                                .entryTtl(Duration.ofSeconds(cacheKey.getExpiryTimeSec()))
+                ));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(defaultCacheConfig)
+                .withInitialCacheConfigurations(cacheConfigurations)
+                .build();
+    }
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/config/RedisConfig.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/config/RedisConfig.java
@@ -5,6 +5,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.cache.CacheKeyPrefix;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
 @Configuration
 @EnableCaching
 @EnableRedisRepositories
+@Profile("test")
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")
@@ -50,7 +52,7 @@ public class RedisConfig {
     }
 
     @Bean
-    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory){
+    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
         RedisCacheConfiguration defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .disableCachingNullValues()
                 .computePrefixWith(CacheKeyPrefix.simple())

--- a/API-Server/src/main/resources/application-dev.yml
+++ b/API-Server/src/main/resources/application-dev.yml
@@ -25,5 +25,5 @@ spring:
 
   data:
     redis:
-      host: ${DEV_REDIS_HOST}
-      port: ${DEV_REDIS_PORT}
+      cluster:
+        nodes: ${DEV_REDIS_NODES}

--- a/API-Server/src/main/resources/application-prod.yml
+++ b/API-Server/src/main/resources/application-prod.yml
@@ -25,5 +25,5 @@ spring:
 
   data:
     redis:
-      host: ${PROD_REDIS_HOST}
-      port: ${PROD_REDIS_PORT}
+      cluster:
+        nodes: ${PROD_REDIS_NODES}


### PR DESCRIPTION
## 📝요약
Redis 구성을 AWS Elastic Cache를 사용하도록 변경하였습니다.
또한 profile에 따라서 참조하는 캐시를 분리하여 Actions에서 발생할 수 있는 이슈를 방지하였습니다.
<br><br>
## 🔥작업 내용 
- test 환경에서는 non cluster mode의 Redis를 사용
- dev와 prod는 각자에게 할당된 cluster mode의 redis를 사용

## 문제 상황
Github Actions에서 Build 작업 수행 시 test code가 실행되는데, Redis 관련 이슈가 있었습니다. 
로컬 개발 환경에서는 VPN을 사용하여 AWS VPC 내부에 있는 Elastic Cache에 접근할 수 있습니다. (VPN없이는 동일 VPC에서만 접근 가능)
하지만, Actions에서는 VPN을 사용하기가 어려워서 Redis Image를 실행시켜 Actions가 사용하는 VM에 redis container를 띄웠고, localhost로 접근하도록 변경하였습니다.

여기서, cluster redis를 도입하는 과정에서 충돌이 발생합니다. 프로파일을 분리하지 않은 상태에서는 모두 동일한 캐시를 참조하는 상황이기 때문에 cluster-mode의 redis를 도입하면 test code가 실패되었습니다.

## 해결 방안
결국 dev, prod에서는 cluster mode를 사용하고, test 환경에서는 non-cluster mode를 사용해야 합니다.
이를 위해서 Configuration class를 둘로 분리하였습니다. 

```java
1. RedisClusterConfig
@Configuration
@EnableCaching
@EnableRedisRepositories
@Profile({"prod", "dev"})
public class RedisClusterConfig {

    @Value("${spring.data.redis.cluster.nodes}")
    private List<String> clusterNodes;

    @Bean
    public RedisConnectionFactory redisConnectionFactory() {
        RedisClusterConfiguration clusterConfiguration = new RedisClusterConfiguration(clusterNodes);
        return new LettuceConnectionFactory(clusterConfiguration);
    }

    @Bean
    public RedisTemplate<?, ?> redisTemplate() {
        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
        redisTemplate.setConnectionFactory(redisConnectionFactory());
        redisTemplate.setKeySerializer(new StringRedisSerializer());
        redisTemplate.setValueSerializer(new StringRedisSerializer());
        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
        return redisTemplate;
    }

    @Bean
    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
        RedisCacheConfiguration defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
                .disableCachingNullValues()
                .computePrefixWith(CacheKeyPrefix.simple())
                .serializeKeysWith(
                        RedisSerializationContext.SerializationPair
                                .fromSerializer(new StringRedisSerializer()))
                .serializeValuesWith(
                        RedisSerializationContext.SerializationPair
                                .fromSerializer(new GenericJackson2JsonRedisSerializer()));

        Map<String, RedisCacheConfiguration> cacheConfigurations = Arrays.stream(CacheKey.values())
                .collect(Collectors.toMap(
                        CacheKey::getKey,
                        cacheKey -> RedisCacheConfiguration.defaultCacheConfig()
                                .entryTtl(Duration.ofSeconds(cacheKey.getExpiryTimeSec()))
                ));

        return RedisCacheManager.RedisCacheManagerBuilder
                .fromConnectionFactory(redisConnectionFactory)
                .cacheDefaults(defaultCacheConfig)
                .withInitialCacheConfigurations(cacheConfigurations)
                .build();
    }
}
```

```java
2. RedisConfig
@Configuration
@EnableCaching
@EnableRedisRepositories
@Profile("test")
public class RedisConfig {

    @Value("${spring.data.redis.host}")
    private String host;

    @Value("${spring.data.redis.port}")
    private int port;

    @Bean
    public RedisConnectionFactory redisConnectionFactory() {
        return new LettuceConnectionFactory(host, port);
    }
	...
	...
}
```

그리고 application.yml을 분리하여 환경마다 다른 캐시를 참조하도록 변경하였습니다.

## 📋참고 사항

## 🎯관련 이슈

- Close #29 