### PR TITLE
미션 등록 Api 

### DIFF
--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/global/constant/ResponseCode.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/global/constant/ResponseCode.java
@@ -52,7 +52,8 @@ public enum ResponseCode {
     MISS_REGISTER_DEADLINE(10300, HttpStatus.BAD_REQUEST, "미션 등록 기간이 이미 마감되었습니다."),
     FULL_REGISTER_MEMBERS(10301, HttpStatus.BAD_REQUEST, "미션 등록 인원이 모두 찼습니다."),
     ALREADY_REGISTERED_MISSION(10302, HttpStatus.BAD_REQUEST, "이미 참가한 미션입니다."),
-    TOO_MANY_LOCK_ERROR(10303, HttpStatus.INTERNAL_SERVER_ERROR, "대기시간이 만료되어 미션 참가에 실패했습니다.")
+    TOO_MANY_LOCK_ERROR(10303, HttpStatus.INTERNAL_SERVER_ERROR, "대기시간이 만료되어 미션 참가에 실패했습니다."),
+    NOT_MY_MISSION(10304, HttpStatus.INTERNAL_SERVER_ERROR, "접근 권한이 없는 미션입니다.")
     ;
 
     private final Integer code;

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/global/constant/ResponseCode.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/global/constant/ResponseCode.java
@@ -53,7 +53,7 @@ public enum ResponseCode {
     FULL_REGISTER_MEMBERS(10301, HttpStatus.BAD_REQUEST, "미션 등록 인원이 모두 찼습니다."),
     ALREADY_REGISTERED_MISSION(10302, HttpStatus.BAD_REQUEST, "이미 참가한 미션입니다."),
     TOO_MANY_LOCK_ERROR(10303, HttpStatus.INTERNAL_SERVER_ERROR, "대기시간이 만료되어 미션 참가에 실패했습니다."),
-    NOT_MY_MISSION(10304, HttpStatus.INTERNAL_SERVER_ERROR, "접근 권한이 없는 미션입니다.")
+    NOT_MY_MISSION(10304, HttpStatus.BAD_REQUEST, "접근 권한이 없는 미션입니다.")
     ;
 
     private final Integer code;

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/global/constant/ResponseCode.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/global/constant/ResponseCode.java
@@ -46,7 +46,11 @@ public enum ResponseCode {
 
     // 102xx : Mission
     NOT_EXIST_MISSION(10200, HttpStatus.BAD_REQUEST, "존재하지 않는 미션입니다."),
-    INVALID_GITHUB_URL(10201, HttpStatus.BAD_REQUEST, "유효하지 않은 Github Repository URL입니다. public repository인 github 주소인지 확인해주세요.");
+    INVALID_GITHUB_URL(10201, HttpStatus.BAD_REQUEST, "유효하지 않은 Github Repository URL입니다. public repository인 github 주소인지 확인해주세요."),
+
+    // 103xx : Mission Registration
+    MISS_REGISTER_DEADLINE(10300, HttpStatus.BAD_REQUEST, "미션 등록 기간이 이미 마감되었습니다."),
+    FULL_REGISTER_MEMBERS(10301, HttpStatus.BAD_REQUEST, "미션 등록 인원이 모두 찼습니다."),
     ;
 
     private final Integer code;

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/global/constant/ResponseCode.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/global/constant/ResponseCode.java
@@ -51,6 +51,8 @@ public enum ResponseCode {
     // 103xx : Mission Registration
     MISS_REGISTER_DEADLINE(10300, HttpStatus.BAD_REQUEST, "미션 등록 기간이 이미 마감되었습니다."),
     FULL_REGISTER_MEMBERS(10301, HttpStatus.BAD_REQUEST, "미션 등록 인원이 모두 찼습니다."),
+    ALREADY_REGISTERED_MISSION(10302, HttpStatus.BAD_REQUEST, "이미 참가한 미션입니다."),
+    TOO_MANY_LOCK_ERROR(10303, HttpStatus.INTERNAL_SERVER_ERROR, "대기시간이 만료되어 미션 참가에 실패했습니다.")
     ;
 
     private final Integer code;

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/member/service/MemberValidator.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/member/service/MemberValidator.java
@@ -8,9 +8,22 @@ import swm.hkcc.LGTM.app.modules.member.exception.NotSeniorMember;
 @Service
 @Transactional
 public class MemberValidator {
-
-    public void validateSenior(Member writer) {
-        if (writer.getSenior() == null)
+    public void validateSenior(Member member) {
+        if (member.getSenior() == null)
             throw new NotSeniorMember();
     }
+
+    public void validateJunior(Member member) {
+        if (member.getJunior() == null)
+            throw new NotSeniorMember();
+    }
+
+    // todo : MemberPostion enum 생성 후 적용하기
+    //    private void validateMemberPosition(Member member, ExpectedPosition expectedRole) {
+    //        if (expectedRole == ExpectedPosition.JUNIOR && member.getJunior() == null) {
+    //            throw new NotJuniorMember();
+    //        } else if (expectedRole == ExpectedPosition.SENIOR && member.getSenior() == null) {
+    //            throw new NotSeniorMember();
+    //        }
+    //    }
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionCustomRepositoryImpl.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionCustomRepositoryImpl.java
@@ -8,7 +8,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
 import swm.hkcc.LGTM.app.modules.mission.domain.MissionStatus;
-import swm.hkcc.LGTM.app.modules.registration.domain.PersonalStatus;
+import swm.hkcc.LGTM.app.modules.registration.domain.ProcessStatus;
 
 import java.util.List;
 
@@ -65,7 +65,7 @@ public class MissionCustomRepositoryImpl implements MissionCustomRepository {
     }
 
     private BooleanExpression isNotCompleted() {
-        return missionRegistration.status.ne(PersonalStatus.MISSION_FINISHED);
+        return missionRegistration.status.ne(ProcessStatus.MISSION_FINISHED);
     }
 
     private BooleanExpression isMissionNotFinished() {

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/controller/RegistrationController.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/controller/RegistrationController.java
@@ -27,7 +27,7 @@ public class RegistrationController {
     public ApiDataResponse<Boolean> enrollMission(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long missionId
-    ) {
+    ) throws InterruptedException {
         Member junior = customUserDetails.getMember();
         registrationService.registerJunior(junior, missionId);
         return ApiDataResponse.of(true);

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/controller/RegistrationController.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/controller/RegistrationController.java
@@ -7,6 +7,7 @@ import swm.hkcc.LGTM.app.global.dto.ApiDataResponse;
 import swm.hkcc.LGTM.app.modules.member.domain.Member;
 import swm.hkcc.LGTM.app.modules.member.domain.custom.CustomUserDetails;
 import swm.hkcc.LGTM.app.modules.registration.service.RegistrationService;
+import swm.hkcc.LGTM.app.modules.registration.dto.RegistrationSeniorResponse;
 
 @RestController
 @RequestMapping("/v1/mission/{missionId}")

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/controller/RegistrationController.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/controller/RegistrationController.java
@@ -27,10 +27,19 @@ public class RegistrationController {
     public ApiDataResponse<Boolean> enrollMission(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long missionId
-    ) {
+    ) throws InterruptedException {
         Member junior = customUserDetails.getMember();
         registrationService.registerJunior(junior, missionId);
         return ApiDataResponse.of(true);
     }
 
+
+    @GetMapping("/senior")
+    public ApiDataResponse<RegistrationSeniorResponse> getSeniorEnrollPage(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long missionId
+    ) {
+        Member senior = customUserDetails.getMember();
+        return ApiDataResponse.of(registrationService.getSeniorEnrollInfo(senior, missionId));
+    }
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/controller/RegistrationController.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/controller/RegistrationController.java
@@ -1,0 +1,36 @@
+package swm.hkcc.LGTM.app.modules.registration.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import swm.hkcc.LGTM.app.global.dto.ApiDataResponse;
+import swm.hkcc.LGTM.app.modules.member.domain.Member;
+import swm.hkcc.LGTM.app.modules.member.domain.custom.CustomUserDetails;
+import swm.hkcc.LGTM.app.modules.registration.service.RegistrationService;
+
+@RestController
+@RequestMapping("/v1/mission/{missionId}")
+@RequiredArgsConstructor
+public class RegistrationController {
+    private final RegistrationService registrationService;
+
+    /**
+     * 주니어가 미션에 참가한다
+     *
+     * @param customUserDetails
+     * @param missionId
+     */
+    @PostMapping
+    public ApiDataResponse<Boolean> enrollMission(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long missionId
+    ) {
+        Member junior = customUserDetails.getMember();
+        registrationService.registerJunior(junior, missionId);
+        return ApiDataResponse.of(true);
+    }
+
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/controller/RegistrationController.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/controller/RegistrationController.java
@@ -2,10 +2,7 @@ package swm.hkcc.LGTM.app.modules.registration.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import swm.hkcc.LGTM.app.global.dto.ApiDataResponse;
 import swm.hkcc.LGTM.app.modules.member.domain.Member;
 import swm.hkcc.LGTM.app.modules.member.domain.custom.CustomUserDetails;

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/controller/RegistrationController.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/controller/RegistrationController.java
@@ -22,7 +22,7 @@ public class RegistrationController {
      * @param missionId
      */
     @PostMapping
-    public ApiDataResponse<Boolean> enrollMission(
+    public ApiDataResponse<Boolean> registerMission(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long missionId
     ) throws InterruptedException {

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/domain/MissionHistory.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/domain/MissionHistory.java
@@ -10,7 +10,6 @@ import swm.hkcc.LGTM.app.global.entity.BaseEntity;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MissionHistory extends BaseEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "history_id")
@@ -19,5 +18,9 @@ public class MissionHistory extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "registration_id")
     private MissionRegistration registration;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProcessStatus status;
 
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/domain/MissionRegistration.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/domain/MissionRegistration.java
@@ -2,6 +2,7 @@ package swm.hkcc.LGTM.app.modules.registration.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 import swm.hkcc.LGTM.app.global.entity.BaseEntity;
 import swm.hkcc.LGTM.app.modules.member.domain.Member;
 import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
@@ -15,7 +16,6 @@ import java.io.Serializable;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MissionRegistration extends BaseEntity implements Serializable {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "registration_id")
@@ -23,7 +23,11 @@ public class MissionRegistration extends BaseEntity implements Serializable {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private PersonalStatus status;
+    private ProcessStatus status;
+
+    @Column(nullable = true)
+    @ColumnDefault("''")
+    private String githubPullRequestUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mission_id")

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/domain/ProcessStatus.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/domain/ProcessStatus.java
@@ -5,15 +5,22 @@ import lombok.Getter;
 @Getter
 public enum ProcessStatus {
 
-    WAITING_FOR_PAYMENT("입금 대기중"),
-    PAYMENT_CONFIRMATION("입금 확인중"),
-    MISSION_PROCEEDING("미션 수행"),
-    CODE_REVIEW("코드 리뷰 작성"),
-    MISSION_FINISHED("미션 완료!");
+    WAITING_FOR_PAYMENT("입금 대기중", false, false, "입금하기"),
+    PAYMENT_CONFIRMATION("입금 확인중", false, false, "입금 확인중"),
+    MISSION_PROCEEDING("미션 수행중", true, false, "미션 수행"),
+    CODE_REVIEW("코드 리뷰 작성", true, true, "코드 리뷰 작성"),
+    MISSION_FINISHED("미션 완료!",  true, true, "미션 완료!"),
+    FEEDBACK_REVIEWED("리뷰 완료!", true, true, "리뷰 완료!");
 
     private final String status;
+    private final boolean isPayed;
+    private final boolean isPullRequestCreated;
+    private final String buttonMessage;
 
-    PersonalStatus(String status) {
+    ProcessStatus(String status, boolean isPayed, boolean isPullRequestCreated, String buttonMessage) {
         this.status = status;
+        this.isPayed = isPayed;
+        this.isPullRequestCreated = isPullRequestCreated;
+        this.buttonMessage = buttonMessage;
     }
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/domain/ProcessStatus.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/domain/ProcessStatus.java
@@ -3,7 +3,7 @@ package swm.hkcc.LGTM.app.modules.registration.domain;
 import lombok.Getter;
 
 @Getter
-public enum PersonalStatus {
+public enum ProcessStatus {
 
     WAITING_FOR_PAYMENT("입금 대기중"),
     PAYMENT_CONFIRMATION("입금 확인중"),

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/domain/ProcessStatus.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/domain/ProcessStatus.java
@@ -4,23 +4,28 @@ import lombok.Getter;
 
 @Getter
 public enum ProcessStatus {
-
-    WAITING_FOR_PAYMENT("입금 대기중", false, false, "입금하기"),
-    PAYMENT_CONFIRMATION("입금 확인중", false, false, "입금 확인중"),
-    MISSION_PROCEEDING("미션 수행중", true, false, "미션 수행"),
-    CODE_REVIEW("코드 리뷰 작성", true, true, "코드 리뷰 작성"),
-    MISSION_FINISHED("미션 완료!",  true, true, "미션 완료!"),
-    FEEDBACK_REVIEWED("리뷰 완료!", true, true, "리뷰 완료!");
+    WAITING_FOR_PAYMENT("입금 대기중", 0, "입금하기"),
+    PAYMENT_CONFIRMATION("입금 확인중", 1, "입금 확인중"),
+    MISSION_PROCEEDING("미션 수행중", 2, "미션 수행"),
+    CODE_REVIEW("코드 리뷰 작성", 3, "코드 리뷰 작성"),
+    MISSION_FINISHED("미션 완료!", 4, "미션 완료!"),
+    FEEDBACK_REVIEWED("리뷰 완료!", 5, "리뷰 완료!");
 
     private final String status;
-    private final boolean isPayed;
-    private final boolean isPullRequestCreated;
+    private final int sequence;
     private final String buttonMessage;
 
-    ProcessStatus(String status, boolean isPayed, boolean isPullRequestCreated, String buttonMessage) {
+    ProcessStatus(String status, int sequence, String buttonMessage) {
         this.status = status;
-        this.isPayed = isPayed;
-        this.isPullRequestCreated = isPullRequestCreated;
+        this.sequence = sequence;
         this.buttonMessage = buttonMessage;
+    }
+
+    public boolean isPayed() {
+        return this.sequence >= MISSION_PROCEEDING.sequence;
+    }
+
+    public boolean isPullRequestCreated() {
+        return this.sequence >= CODE_REVIEW.sequence;
     }
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/dto/MemberRegisterSimpleInfo.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/dto/MemberRegisterSimpleInfo.java
@@ -1,7 +1,5 @@
 package swm.hkcc.LGTM.app.modules.registration.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.querydsl.core.Tuple;
 import lombok.Data;
 import swm.hkcc.LGTM.app.modules.registration.domain.ProcessStatus;

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/dto/MemberRegisterSimpleInfo.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/dto/MemberRegisterSimpleInfo.java
@@ -1,0 +1,41 @@
+package swm.hkcc.LGTM.app.modules.registration.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.querydsl.core.Tuple;
+import lombok.Data;
+import swm.hkcc.LGTM.app.modules.registration.domain.ProcessStatus;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static swm.hkcc.LGTM.app.modules.member.domain.QMember.member;
+import static swm.hkcc.LGTM.app.modules.registration.domain.QMissionRegistration.missionRegistration;
+
+@Data
+public class MemberRegisterSimpleInfo implements Serializable {
+    private Long memberId;
+    private String nickname;
+    private String githubId;
+    private String profileImageUrl;
+    private ProcessStatus processStatus;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime paymentDate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime missionFinishedDate;
+
+    private String githubPrUrl = "";
+
+    public static MemberRegisterSimpleInfo createMemberRegisterInfo(Tuple tuple) {
+        MemberRegisterSimpleInfo memberRegisterSimpleInfo = new MemberRegisterSimpleInfo();
+        memberRegisterSimpleInfo.memberId = tuple.get(member.memberId);
+        memberRegisterSimpleInfo.nickname = tuple.get(member.nickName);
+        memberRegisterSimpleInfo.githubId = tuple.get(member.githubId);
+        memberRegisterSimpleInfo.profileImageUrl = tuple.get(member.profileImageUrl);
+        memberRegisterSimpleInfo.processStatus = tuple.get(missionRegistration.status);
+        memberRegisterSimpleInfo.githubPrUrl = Optional.ofNullable(tuple.get(missionRegistration.githubPullRequestUrl)).orElse("");
+        return memberRegisterSimpleInfo;
+    }
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/dto/MemberRegisterSimpleInfo.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/dto/MemberRegisterSimpleInfo.java
@@ -1,6 +1,7 @@
 package swm.hkcc.LGTM.app.modules.registration.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.querydsl.core.Tuple;
 import lombok.Data;
 import swm.hkcc.LGTM.app.modules.registration.domain.ProcessStatus;
@@ -19,13 +20,8 @@ public class MemberRegisterSimpleInfo implements Serializable {
     private String githubId;
     private String profileImageUrl;
     private ProcessStatus processStatus;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
-    private LocalDateTime paymentDate;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
-    private LocalDateTime missionFinishedDate;
-
+    private String paymentDate = "";
+    private String missionFinishedDate = "";
     private String githubPrUrl = "";
 
     public static MemberRegisterSimpleInfo createMemberRegisterInfo(Tuple tuple) {
@@ -37,5 +33,15 @@ public class MemberRegisterSimpleInfo implements Serializable {
         memberRegisterSimpleInfo.processStatus = tuple.get(missionRegistration.status);
         memberRegisterSimpleInfo.githubPrUrl = Optional.ofNullable(tuple.get(missionRegistration.githubPullRequestUrl)).orElse("");
         return memberRegisterSimpleInfo;
+    }
+
+    public void setPaymentDate(LocalDateTime paymentDate) {
+        if (paymentDate != null)
+            this.paymentDate = paymentDate.toString();
+    }
+
+    public void setMissionFinishedDate(LocalDateTime missionFinishedDate) {
+        if (missionFinishedDate != null)
+            this.missionFinishedDate = missionFinishedDate.toString();
     }
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/dto/RegistrationSeniorResponse.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/dto/RegistrationSeniorResponse.java
@@ -1,0 +1,14 @@
+package swm.hkcc.LGTM.app.modules.registration.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import swm.hkcc.LGTM.app.modules.tag.domain.TechTag;
+
+import java.util.List;
+
+@Data @Builder
+public class RegistrationSeniorResponse {
+    private String missionName;
+    private List<TechTag> techTagList;
+    private List<MemberRegisterSimpleInfo> memberInfoList;
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/exception/AlreadyRegisteredMission.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/exception/AlreadyRegisteredMission.java
@@ -1,0 +1,10 @@
+package swm.hkcc.LGTM.app.modules.registration.exception;
+
+import swm.hkcc.LGTM.app.global.constant.ResponseCode;
+import swm.hkcc.LGTM.app.global.exception.GeneralException;
+
+public class AlreadyRegisteredMission extends GeneralException {
+    public AlreadyRegisteredMission() {
+        super(ResponseCode.ALREADY_REGISTERED_MISSION);
+    }
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/exception/FullRegisterMembers.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/exception/FullRegisterMembers.java
@@ -1,0 +1,10 @@
+package swm.hkcc.LGTM.app.modules.registration.exception;
+
+import swm.hkcc.LGTM.app.global.constant.ResponseCode;
+import swm.hkcc.LGTM.app.global.exception.GeneralException;
+
+public class FullRegisterMembers extends GeneralException {
+    public FullRegisterMembers(){
+        super(ResponseCode.FULL_REGISTER_MEMBERS);
+    }
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/exception/MissRegisterDeadline.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/exception/MissRegisterDeadline.java
@@ -1,0 +1,10 @@
+package swm.hkcc.LGTM.app.modules.registration.exception;
+
+import swm.hkcc.LGTM.app.global.constant.ResponseCode;
+import swm.hkcc.LGTM.app.global.exception.GeneralException;
+
+public class MissRegisterDeadline extends GeneralException {
+    public MissRegisterDeadline() {
+        super(ResponseCode.MISS_REGISTER_DEADLINE);
+    }
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/exception/NotMyMission.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/exception/NotMyMission.java
@@ -1,0 +1,10 @@
+package swm.hkcc.LGTM.app.modules.registration.exception;
+
+import swm.hkcc.LGTM.app.global.constant.ResponseCode;
+import swm.hkcc.LGTM.app.global.exception.GeneralException;
+
+public class NotMyMission extends GeneralException {
+    public NotMyMission(){
+        super(ResponseCode.NOT_MY_MISSION);
+    }
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/exception/TooManyLockError.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/exception/TooManyLockError.java
@@ -1,0 +1,10 @@
+package swm.hkcc.LGTM.app.modules.registration.exception;
+
+import swm.hkcc.LGTM.app.global.constant.ResponseCode;
+import swm.hkcc.LGTM.app.global.exception.GeneralException;
+
+public class TooManyLockError extends GeneralException {
+    public TooManyLockError() {
+        super(ResponseCode.TOO_MANY_LOCK_ERROR);
+    }
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/mapper/RegistrationMapper.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/mapper/RegistrationMapper.java
@@ -1,0 +1,24 @@
+package swm.hkcc.LGTM.app.modules.registration.mapper;
+
+import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
+import swm.hkcc.LGTM.app.modules.registration.dto.MemberRegisterSimpleInfo;
+import swm.hkcc.LGTM.app.modules.registration.dto.RegistrationSeniorResponse;
+import swm.hkcc.LGTM.app.modules.tag.domain.TechTag;
+
+import java.util.List;
+
+public class RegistrationMapper {
+
+    public static RegistrationSeniorResponse toRegistrationSeniorResponse(
+            Mission mission,
+            List<TechTag> techTagList,
+            List<MemberRegisterSimpleInfo> memberInfoList
+    ) {
+
+        return RegistrationSeniorResponse.builder()
+                .missionName(mission.getTitle())
+                .techTagList(techTagList)
+                .memberInfoList(memberInfoList)
+                .build();
+    }
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionHistoryRepository.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionHistoryRepository.java
@@ -1,0 +1,8 @@
+package swm.hkcc.LGTM.app.modules.registration.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import swm.hkcc.LGTM.app.modules.registration.domain.MissionHistory;
+
+public interface MissionHistoryRepository extends JpaRepository<MissionHistory, Long> {
+
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionRegistrationCustomRepository.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionRegistrationCustomRepository.java
@@ -1,0 +1,18 @@
+package swm.hkcc.LGTM.app.modules.registration.repository;
+
+import com.querydsl.core.Tuple;
+import swm.hkcc.LGTM.app.modules.member.domain.Member;
+import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
+import swm.hkcc.LGTM.app.modules.registration.domain.MissionHistory;
+import swm.hkcc.LGTM.app.modules.registration.domain.ProcessStatus;
+import swm.hkcc.LGTM.app.modules.registration.dto.MemberRegisterSimpleInfo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface MissionRegistrationCustomRepository {
+    public List<MemberRegisterSimpleInfo> getRegisteredMembersByMission(Long missionId);
+    public Optional<LocalDateTime> getStatusDateTime(ProcessStatus status, Mission mission, Member junior);
+
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionRegistrationCustomRepository.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionRegistrationCustomRepository.java
@@ -1,0 +1,4 @@
+package swm.hkcc.LGTM.app.modules.registration.repository;
+
+public interface MissionRegistrationCustomRepository {
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionRegistrationCustomRepositoryImpl.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionRegistrationCustomRepositoryImpl.java
@@ -1,0 +1,50 @@
+package swm.hkcc.LGTM.app.modules.registration.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import swm.hkcc.LGTM.app.modules.member.domain.Member;
+import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
+import swm.hkcc.LGTM.app.modules.registration.domain.MissionHistory;
+import swm.hkcc.LGTM.app.modules.registration.domain.ProcessStatus;
+import swm.hkcc.LGTM.app.modules.registration.dto.MemberRegisterSimpleInfo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static swm.hkcc.LGTM.app.modules.member.domain.QMember.member;
+import static swm.hkcc.LGTM.app.modules.mission.domain.QMission.mission;
+import static swm.hkcc.LGTM.app.modules.registration.domain.QMissionHistory.missionHistory;
+import static swm.hkcc.LGTM.app.modules.registration.domain.QMissionRegistration.missionRegistration;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class MissionRegistrationCustomRepositoryImpl implements MissionRegistrationCustomRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+    @Override
+    public List<MemberRegisterSimpleInfo> getRegisteredMembersByMission(Long missionId) {
+        List<Tuple> tuples = jpaQueryFactory.select(member.memberId, member.nickName, member.githubId, member.profileImageUrl, missionRegistration.githubPullRequestUrl, missionRegistration.status)
+                .from(mission)
+                .innerJoin(missionRegistration).on(mission.missionId.eq(missionRegistration.mission.missionId))
+                .leftJoin(member).on(missionRegistration.junior.memberId.eq(member.memberId))
+                .where(mission.missionId.eq(missionId))
+                .orderBy(missionRegistration.createdAt.asc())
+                .fetch();
+
+        return tuples.stream().map(MemberRegisterSimpleInfo::createMemberRegisterInfo).collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<LocalDateTime> getStatusDateTime(ProcessStatus status, Mission mission, Member junior) {
+        return Optional.ofNullable(jpaQueryFactory.select(missionHistory.createdAt)
+                .from(missionRegistration)
+                .leftJoin(missionHistory).on(missionRegistration.eq(missionHistory.registration))
+                .where(missionRegistration.mission.eq(mission), missionRegistration.junior.eq(junior), missionRegistration.status.eq(status))
+                .fetchOne());
+    }
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionRegistrationRepository.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionRegistrationRepository.java
@@ -7,8 +7,8 @@ import swm.hkcc.LGTM.app.modules.registration.domain.MissionRegistration;
 import java.util.List;
 import java.util.Optional;
 
-public interface MissionRegistrationRepository extends JpaRepository<MissionRegistration, Long> {
-    @Cacheable(value = "mission_participant_count", key = "#missionId")
+public interface MissionRegistrationRepository extends JpaRepository<MissionRegistration, Long>, MissionRegistrationCustomRepository {
+    @Cacheable(value = "mission_participant_count", key = "#p0")
     int countByMission_MissionId(Long missionId);
 
     int countByMission_MissionIdAndJunior_MemberId(Long missionId, Long juniorId);

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionRegistrationRepository.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionRegistrationRepository.java
@@ -7,4 +7,6 @@ import swm.hkcc.LGTM.app.modules.registration.domain.MissionRegistration;
 public interface MissionRegistrationRepository extends JpaRepository<MissionRegistration, Long> {
     @Cacheable(value = "mission_participant_count", key = "#missionId")
     int countByMission_MissionId(Long missionId);
+
+    int countByMission_MissionIdAndJunior_MemberId(Long missionId, Long juniorId);
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionRegistrationRepository.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/MissionRegistrationRepository.java
@@ -4,7 +4,12 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import swm.hkcc.LGTM.app.modules.registration.domain.MissionRegistration;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface MissionRegistrationRepository extends JpaRepository<MissionRegistration, Long> {
     @Cacheable(value = "mission_participant_count", key = "#missionId")
     int countByMission_MissionId(Long missionId);
+
+    int countByMission_MissionIdAndJunior_MemberId(Long missionId, Long juniorId);
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/RedisLockRepository.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/repository/RedisLockRepository.java
@@ -1,0 +1,26 @@
+package swm.hkcc.LGTM.app.modules.registration.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+public class RedisLockRepository {
+    private RedisTemplate<String, String> redisTemplate;
+
+    public RedisLockRepository(final RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public Boolean lock(final Long key) {
+        return redisTemplate
+                .opsForValue()
+                .setIfAbsent(String.valueOf(key), "lock", Duration.ofMillis(3_000));
+    }
+
+    public Boolean unlock(final Long key) {
+        return redisTemplate.delete(String.valueOf(key));
+    }
+
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
@@ -69,18 +69,6 @@ public class RegistrationService {
         return toRegistrationSeniorResponse(mission, techTagList, memberInfoList);
     }
 
-    private void validateJunior(Member junior) {
-        if (junior.getJunior() == null) {
-            throw new NotJuniorMember();
-        }
-    }
-
-    private void validateSenior(Member senior) {
-        if (senior.getSenior() == null) {
-            throw new NotSeniorMember();
-        }
-    }
-
     private void validateMemberPosition(Member member, ExpectedPosition expectedRole) {
         if (expectedRole == ExpectedPosition.JUNIOR && member.getJunior() == null) {
             throw new NotJuniorMember();

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
@@ -6,8 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import swm.hkcc.LGTM.app.modules.member.domain.Member;
-import swm.hkcc.LGTM.app.modules.member.exception.NotJuniorMember;
-import swm.hkcc.LGTM.app.modules.member.exception.NotSeniorMember;
 import swm.hkcc.LGTM.app.modules.member.service.MemberValidator;
 import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
 import swm.hkcc.LGTM.app.modules.mission.exception.NotExistMission;
@@ -17,14 +15,13 @@ import swm.hkcc.LGTM.app.modules.registration.domain.MissionRegistration;
 import swm.hkcc.LGTM.app.modules.registration.domain.ProcessStatus;
 import swm.hkcc.LGTM.app.modules.registration.dto.MemberRegisterSimpleInfo;
 import swm.hkcc.LGTM.app.modules.registration.dto.RegistrationSeniorResponse;
-import swm.hkcc.LGTM.app.modules.registration.exception.*;
+import swm.hkcc.LGTM.app.modules.registration.exception.TooManyLockError;
 import swm.hkcc.LGTM.app.modules.registration.repository.MissionHistoryRepository;
 import swm.hkcc.LGTM.app.modules.registration.repository.MissionRegistrationRepository;
 import swm.hkcc.LGTM.app.modules.registration.repository.RedisLockRepository;
 import swm.hkcc.LGTM.app.modules.tag.domain.TechTag;
 import swm.hkcc.LGTM.app.modules.tag.repository.TechTagPerMissionRepository;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import static swm.hkcc.LGTM.app.modules.registration.mapper.RegistrationMapper.toRegistrationSeniorResponse;
@@ -60,8 +57,9 @@ public class RegistrationService {
     }
 
     public RegistrationSeniorResponse getSeniorEnrollInfo(Member senior, Long missionId) {
-        validateMemberPosition(senior, ExpectedPosition.SENIOR);
-        Mission mission = getValidMissionForSenior(missionId, senior.getMemberId());
+        memberValidator.validateSenior(senior);
+        Mission mission = missionRepository.findById(missionId).orElseThrow(NotExistMission::new);
+        registrationValidator.validateMissionForSenior(mission, senior.getMemberId());
 
         List<TechTag> techTagList = techTagPerMissionRepository.findTechTagsByMissionId(mission.getMissionId());
 
@@ -76,32 +74,6 @@ public class RegistrationService {
             }
         });
         return toRegistrationSeniorResponse(mission, techTagList, memberInfoList);
-    }
-
-    private void validateMemberPosition(Member member, ExpectedPosition expectedRole) {
-        if (expectedRole == ExpectedPosition.JUNIOR && member.getJunior() == null) {
-            throw new NotJuniorMember();
-        } else if (expectedRole == ExpectedPosition.SENIOR && member.getSenior() == null) {
-            throw new NotSeniorMember();
-        }
-    }
-
-    // todo : validator 분리
-    private Mission validateToRegisterMission(Mission mission, Long memberId) {
-        // 이미 등록된 미션인지
-        if (missionRegistrationRepository.countByMission_MissionIdAndJunior_MemberId(mission.getMissionId(), memberId) > 0) {
-            throw new AlreadyRegisteredMission();
-        }
-        // 미션 마감일이 지난 경우
-        if (mission.getRegistrationDueDate().isBefore(LocalDate.now())) {
-            throw new MissRegisterDeadline();
-        }
-        // 미션 등록인원이 넘치는 경우
-        int countRegisters = missionRegistrationRepository.countByMission_MissionId(mission.getMissionId());
-        if (mission.getMaxPeopleNumber() <= countRegisters) {
-            throw new FullRegisterMembers();
-        }
-        return mission;
     }
 
     private void acquireLock(Long missionId) throws InterruptedException {

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import swm.hkcc.LGTM.app.modules.member.domain.Member;
 import swm.hkcc.LGTM.app.modules.member.exception.NotJuniorMember;
 import swm.hkcc.LGTM.app.modules.member.exception.NotSeniorMember;
+import swm.hkcc.LGTM.app.modules.member.service.MemberValidator;
 import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
 import swm.hkcc.LGTM.app.modules.mission.exception.NotExistMission;
 import swm.hkcc.LGTM.app.modules.mission.repository.MissionRepository;
@@ -16,10 +17,7 @@ import swm.hkcc.LGTM.app.modules.registration.domain.MissionRegistration;
 import swm.hkcc.LGTM.app.modules.registration.domain.ProcessStatus;
 import swm.hkcc.LGTM.app.modules.registration.dto.MemberRegisterSimpleInfo;
 import swm.hkcc.LGTM.app.modules.registration.dto.RegistrationSeniorResponse;
-import swm.hkcc.LGTM.app.modules.registration.exception.AlreadyRegisteredMission;
-import swm.hkcc.LGTM.app.modules.registration.exception.FullRegisterMembers;
-import swm.hkcc.LGTM.app.modules.registration.exception.MissRegisterDeadline;
-import swm.hkcc.LGTM.app.modules.registration.exception.TooManyLockError;
+import swm.hkcc.LGTM.app.modules.registration.exception.*;
 import swm.hkcc.LGTM.app.modules.registration.repository.MissionHistoryRepository;
 import swm.hkcc.LGTM.app.modules.registration.repository.MissionRegistrationRepository;
 import swm.hkcc.LGTM.app.modules.registration.repository.RedisLockRepository;
@@ -41,18 +39,20 @@ public class RegistrationService {
     private final MissionHistoryRepository missionHistoryRepository;
     private final TechTagPerMissionRepository techTagPerMissionRepository;
     private final RedisLockRepository redisLockRepository;
+    private final RegistrationValidator registrationValidator;
+    private final MemberValidator memberValidator;
     private static final int MAX_LOCK_RETRIES = 10;
     private static final int LOCK_RETRY_DELAY_MS = 100;
 
 
     public long registerJunior(Member junior, Long missionId) throws InterruptedException {
-        validateMemberPosition(junior, ExpectedPosition.JUNIOR);
+        memberValidator.validateJunior(junior);
         Mission mission = missionRepository.findById(missionId).orElseThrow(NotExistMission::new);
 
         // todo: rdb lock 고려해보기
         acquireLock(mission.getMissionId());
         try {
-            validateToRegisterMission(mission, junior.getMemberId());
+            registrationValidator.validateToRegisterMission(mission, junior.getMemberId());
             return processMissionRegistration(junior, mission);
         } finally {
             redisLockRepository.unlock(mission.getMissionId());
@@ -92,11 +92,6 @@ public class RegistrationService {
         }
     }
 
-    private void validateSenior(Member senior) {
-        if (senior.getSenior() == null) {
-            throw new NotSeniorMember();
-        }
-    }
 
     private void validateMemberPosition(Member member, ExpectedPosition expectedRole) {
         if (expectedRole == ExpectedPosition.JUNIOR && member.getJunior() == null) {
@@ -149,8 +144,5 @@ public class RegistrationService {
         missionHistoryRepository.save(missionHistory);
         return missionRegistration.getRegistrationId();
     }
-}
 
-enum ExpectedPosition {
-    JUNIOR, SENIOR
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
@@ -36,6 +36,10 @@ public class RegistrationService {
     public long registerJunior(Member junior, Long missionId) throws InterruptedException {
         validateJunior(junior);
         Mission mission = missionRepository.findById(missionId).orElseThrow(NotExistMission::new);
+        if (missionRegistrationRepository.countByMission_MissionIdAndJunior_MemberId(missionId, junior.getMemberId()) > 0) {
+            throw new AlreadyRegisteredMission();
+        }
+
         int countRegisters = missionRegistrationRepository.countByMission_MissionId(missionId);
 
         validateMission(mission, countRegisters);

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
@@ -86,12 +86,6 @@ public class RegistrationService {
         return toRegistrationSeniorResponse(mission, techTagList, memberInfoList);
     }
 
-    private void validateJunior(Member junior) {
-        if (junior.getJunior() == null) {
-            throw new NotJuniorMember();
-        }
-    }
-
 
     private void validateMemberPosition(Member member, ExpectedPosition expectedRole) {
         if (expectedRole == ExpectedPosition.JUNIOR && member.getJunior() == null) {

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
@@ -1,0 +1,84 @@
+package swm.hkcc.LGTM.app.modules.registration.service;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import swm.hkcc.LGTM.app.modules.member.domain.Member;
+import swm.hkcc.LGTM.app.modules.member.exception.NotJuniorMember;
+import swm.hkcc.LGTM.app.modules.member.exception.NotSeniorMember;
+import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
+import swm.hkcc.LGTM.app.modules.mission.exception.NotExistMission;
+import swm.hkcc.LGTM.app.modules.mission.repository.MissionRepository;
+import swm.hkcc.LGTM.app.modules.registration.domain.MissionHistory;
+import swm.hkcc.LGTM.app.modules.registration.domain.MissionRegistration;
+import swm.hkcc.LGTM.app.modules.registration.domain.ProcessStatus;
+import swm.hkcc.LGTM.app.modules.registration.exception.FullRegisterMembers;
+import swm.hkcc.LGTM.app.modules.registration.exception.MissRegisterDeadline;
+import swm.hkcc.LGTM.app.modules.registration.repository.MissionHistoryRepository;
+import swm.hkcc.LGTM.app.modules.registration.repository.MissionRegistrationRepository;
+import swm.hkcc.LGTM.app.modules.tag.repository.TechTagPerMissionRepository;
+
+import java.time.LocalDate;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class RegistrationService {
+    private final MissionRepository missionRepository;
+    private final MissionRegistrationRepository missionRegistrationRepository;
+    private final MissionHistoryRepository missionHistoryRepository;
+    private final TechTagPerMissionRepository techTagPerMissionRepository;
+
+    public long registerJunior(Member junior, Long missionId) {
+        // todo : 이미 참가한 미션인 경우
+        validateJunior(junior);
+        Mission mission = missionRepository.findById(missionId).orElseThrow(NotExistMission::new);
+        int countRegisters = missionRegistrationRepository.countByMission_MissionId(missionId);
+
+        validateMission(mission, countRegisters);
+
+        MissionRegistration missionRegistration = MissionRegistration.builder()
+                .mission(mission)
+                .junior(junior)
+                .status(ProcessStatus.WAITING_FOR_PAYMENT)
+                .build();
+        missionRegistrationRepository.save(missionRegistration);
+
+        MissionHistory missionHistory = MissionHistory.builder()
+                .registration(missionRegistration)
+                .status(ProcessStatus.WAITING_FOR_PAYMENT)
+                .build();
+
+        missionHistoryRepository.save(missionHistory);
+
+        // todo : 동시성 처리
+        return missionRegistration.getRegistrationId();
+    }
+
+    private void validateJunior(Member junior) {
+        if (junior.getJunior() == null) {
+            throw new NotJuniorMember();
+        }
+    }
+
+    private void validateSenior(Member senior) {
+        if (senior.getSenior() == null) {
+            throw new NotSeniorMember();
+        }
+    }
+
+    private void validateMission(Mission mission, int countRegisters) {
+        // 미션 마감일이 지난 경우
+        if (mission.getRegistrationDueDate().isBefore(LocalDate.now())) {
+            throw new MissRegisterDeadline();
+        }
+        // 미션 등록인원이 넘치는 경우
+        if (mission.getMaxPeopleNumber() <= countRegisters) {
+            throw new FullRegisterMembers();
+        }
+    }
+
+}

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
@@ -38,6 +38,9 @@ public class RegistrationService {
     private final MissionHistoryRepository missionHistoryRepository;
     private final TechTagPerMissionRepository techTagPerMissionRepository;
     private final RedisLockRepository redisLockRepository;
+    private static final int MAX_LOCK_RETRIES = 10;
+    private static final int LOCK_RETRY_DELAY_MS = 100;
+
 
     public long registerJunior(Member junior, Long missionId) throws InterruptedException {
         validateMemberPosition(junior, ExpectedPosition.JUNIOR);
@@ -98,16 +101,16 @@ public class RegistrationService {
     private Mission getValidMissionForSenior(Long missionId, Long memberId) {
         Mission mission = missionRepository.findById(missionId).orElseThrow(NotExistMission::new);
         // 자신의 미션이 아닌 경우
-        if (mission.getWriter().getMemberId() != memberId) {
+        if (!mission.getWriter().getMemberId().equals(memberId)) {
             throw new NotMyMission();
         }
         return mission;
     }
 
     private void acquireLock(Long missionId) throws InterruptedException {
-        int retries = 10;  // 최대 10번 재시도
+        int retries = MAX_LOCK_RETRIES;  // 최대 10번 재시도
         while (retries-- > 0 && !redisLockRepository.lock(missionId)) {
-            Thread.sleep(100);
+            Thread.sleep(LOCK_RETRY_DELAY_MS);
         }
         if (retries <= 0) {
             throw new TooManyLockError();

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
@@ -46,6 +46,7 @@ public class RegistrationService {
         memberValidator.validateJunior(junior);
         Mission mission = missionRepository.findById(missionId).orElseThrow(NotExistMission::new);
 
+        // todo : 동시성 테스트하기
         // todo: rdb lock 고려해보기
         acquireLock(mission.getMissionId());
         try {

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
@@ -34,33 +34,12 @@ public class RegistrationService {
     private final RedisLockRepository redisLockRepository;
 
     public long registerJunior(Member junior, Long missionId) throws InterruptedException {
-        validateJunior(junior);
-        Mission mission = missionRepository.findById(missionId).orElseThrow(NotExistMission::new);
-        if (missionRegistrationRepository.countByMission_MissionIdAndJunior_MemberId(missionId, junior.getMemberId()) > 0) {
-            throw new AlreadyRegisteredMission();
-        }
+        validateMemberPosition(junior, ExpectedPosition.JUNIOR);
+        Mission mission = getValidMission(missionId, junior.getMemberId());
 
-        int countRegisters = missionRegistrationRepository.countByMission_MissionId(missionId);
-
-        validateMission(mission, countRegisters);
-
-        while (!redisLockRepository.lock(mission.getMissionId())) {
-            Thread.sleep(100);
-        }
+        acquireLock(mission.getMissionId());
         try {
-            MissionRegistration missionRegistration = MissionRegistration.builder()
-                    .mission(mission)
-                    .junior(junior)
-                    .status(ProcessStatus.WAITING_FOR_PAYMENT)
-                    .build();
-            missionRegistrationRepository.save(missionRegistration);
-
-            MissionHistory missionHistory = MissionHistory.builder()
-                    .registration(missionRegistration)
-                    .status(ProcessStatus.WAITING_FOR_PAYMENT)
-                    .build();
-            missionHistoryRepository.save(missionHistory);
-            return missionRegistration.getRegistrationId();
+            return processMissionRegistration(junior, mission);
         } finally {
             redisLockRepository.unlock(mission.getMissionId());
         }
@@ -78,15 +57,60 @@ public class RegistrationService {
         }
     }
 
-    private void validateMission(Mission mission, int countRegisters) {
+    private void validateMemberPosition(Member member, ExpectedPosition expectedRole) {
+        if (expectedRole == ExpectedPosition.JUNIOR && member.getJunior() == null) {
+            throw new NotJuniorMember();
+        } else if (expectedRole == ExpectedPosition.SENIOR && member.getSenior() == null) {
+            throw new NotSeniorMember();
+        }
+    }
+
+    private Mission getValidMission(Long missionId, Long memberId) {
+        Mission mission = missionRepository.findById(missionId).orElseThrow(NotExistMission::new);
+        // 이미 등록된 미션인지
+        if (missionRegistrationRepository.countByMission_MissionIdAndJunior_MemberId(mission.getMissionId(), memberId) > 0) {
+            throw new AlreadyRegisteredMission();
+        }
         // 미션 마감일이 지난 경우
         if (mission.getRegistrationDueDate().isBefore(LocalDate.now())) {
             throw new MissRegisterDeadline();
         }
         // 미션 등록인원이 넘치는 경우
+        int countRegisters = missionRegistrationRepository.countByMission_MissionId(mission.getMissionId());
         if (mission.getMaxPeopleNumber() <= countRegisters) {
             throw new FullRegisterMembers();
         }
+        return mission;
     }
 
+    private void acquireLock(Long missionId) throws InterruptedException {
+        int retries = 10;  // 최대 10번 재시도
+        while (retries-- > 0 && !redisLockRepository.lock(missionId)) {
+            Thread.sleep(100);
+        }
+        if (retries <= 0) {
+            throw new RuntimeException("Unable to acquire lock for mission: " + missionId);
+        }
+    }
+
+    private Long processMissionRegistration(Member junior, Mission mission) {
+        MissionRegistration missionRegistration = MissionRegistration.builder()
+                .mission(mission)
+                .junior(junior)
+                .status(ProcessStatus.WAITING_FOR_PAYMENT)
+                .build();
+        missionRegistrationRepository.save(missionRegistration);
+
+        MissionHistory missionHistory = MissionHistory.builder()
+                .registration(missionRegistration)
+                .status(ProcessStatus.WAITING_FOR_PAYMENT)
+                .build();
+        missionHistoryRepository.save(missionHistory);
+        return missionRegistration.getRegistrationId();
+    }
+
+}
+
+enum ExpectedPosition {
+    JUNIOR, SENIOR
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
@@ -41,6 +41,9 @@ public class RegistrationService {
     private final MissionHistoryRepository missionHistoryRepository;
     private final TechTagPerMissionRepository techTagPerMissionRepository;
     private final RedisLockRepository redisLockRepository;
+    private static final int MAX_LOCK_RETRIES = 10;
+    private static final int LOCK_RETRY_DELAY_MS = 100;
+
 
     public long registerJunior(Member junior, Long missionId) throws InterruptedException {
         validateMemberPosition(junior, ExpectedPosition.JUNIOR);
@@ -120,9 +123,9 @@ public class RegistrationService {
     }
 
     private void acquireLock(Long missionId) throws InterruptedException {
-        int retries = 10;  // 최대 10번 재시도
+        int retries = MAX_LOCK_RETRIES;  // 최대 10번 재시도
         while (retries-- > 0 && !redisLockRepository.lock(missionId)) {
-            Thread.sleep(100);
+            Thread.sleep(LOCK_RETRY_DELAY_MS);
         }
         if (retries <= 0) {
             throw new TooManyLockError();

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
@@ -60,6 +60,7 @@ public class RegistrationService {
 
         List<TechTag> techTagList = techTagPerMissionRepository.findTechTagsByMissionId(mission.getMissionId());
 
+        // todo : isPayed & isPullRequestCreated registration에 추가해서 한번에 조회
         List<MemberRegisterSimpleInfo> memberInfoList = missionRegistrationRepository.getRegisteredMembersByMission(missionId);
         memberInfoList.forEach(memberInfo -> {
             if (memberInfo.getProcessStatus().isPayed()) {

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationValidator.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationValidator.java
@@ -2,10 +2,12 @@ package swm.hkcc.LGTM.app.modules.registration.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import swm.hkcc.LGTM.app.modules.member.domain.Junior;
 import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
 import swm.hkcc.LGTM.app.modules.registration.exception.AlreadyRegisteredMission;
 import swm.hkcc.LGTM.app.modules.registration.exception.FullRegisterMembers;
 import swm.hkcc.LGTM.app.modules.registration.exception.MissRegisterDeadline;
+import swm.hkcc.LGTM.app.modules.registration.exception.NotMyMission;
 import swm.hkcc.LGTM.app.modules.registration.repository.MissionRegistrationRepository;
 
 import java.time.LocalDate;
@@ -24,6 +26,11 @@ public class RegistrationValidator {
         validateMissionMaxPeopleNumber(mission);
     }
 
+    public void validateMissionForSenior(Mission mission, Long memberId) {
+        // 자신의 미션이 아닌 경우
+        validateNotMyMission(mission, memberId);
+    }
+
     private void validateNotRegisteredMission(Mission mission, Long memberId) {
         if (missionRegistrationRepository.countByMission_MissionIdAndJunior_MemberId(mission.getMissionId(), memberId) > 0) {
             throw new AlreadyRegisteredMission();
@@ -40,6 +47,12 @@ public class RegistrationValidator {
         int countRegisters = missionRegistrationRepository.countByMission_MissionId(mission.getMissionId());
         if (mission.getMaxPeopleNumber() <= countRegisters) {
             throw new FullRegisterMembers();
+        }
+    }
+
+    private void validateNotMyMission(Mission mission, Long memberId) {
+        if (!mission.getWriter().getMemberId().equals(memberId)) {
+            throw new NotMyMission();
         }
     }
 }

--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationValidator.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationValidator.java
@@ -1,0 +1,45 @@
+package swm.hkcc.LGTM.app.modules.registration.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
+import swm.hkcc.LGTM.app.modules.registration.exception.AlreadyRegisteredMission;
+import swm.hkcc.LGTM.app.modules.registration.exception.FullRegisterMembers;
+import swm.hkcc.LGTM.app.modules.registration.exception.MissRegisterDeadline;
+import swm.hkcc.LGTM.app.modules.registration.repository.MissionRegistrationRepository;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class RegistrationValidator {
+    private final MissionRegistrationRepository missionRegistrationRepository;
+
+    public void validateToRegisterMission(Mission mission, Long memberId) {
+        // 이미 등록된 미션인지
+        validateNotRegisteredMission(mission, memberId);
+        // 미션 마감일이 지난 경우
+        validateMissionDueDate(mission);
+        // 미션 등록인원이 넘치는 경우
+        validateMissionMaxPeopleNumber(mission);
+    }
+
+    private void validateNotRegisteredMission(Mission mission, Long memberId) {
+        if (missionRegistrationRepository.countByMission_MissionIdAndJunior_MemberId(mission.getMissionId(), memberId) > 0) {
+            throw new AlreadyRegisteredMission();
+        }
+    }
+
+    private void validateMissionDueDate(Mission mission) {
+        if (mission.getRegistrationDueDate().isBefore(LocalDate.now())) {
+            throw new MissRegisterDeadline();
+        }
+    }
+
+    private void validateMissionMaxPeopleNumber(Mission mission) {
+        int countRegisters = missionRegistrationRepository.countByMission_MissionId(mission.getMissionId());
+        if (mission.getMaxPeopleNumber() <= countRegisters) {
+            throw new FullRegisterMembers();
+        }
+    }
+}

--- a/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionCustomRepositoryImplTest.java
+++ b/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/mission/repository/MissionCustomRepositoryImplTest.java
@@ -13,7 +13,7 @@ import swm.hkcc.LGTM.app.modules.member.repository.MemberRepository;
 import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
 import swm.hkcc.LGTM.app.modules.mission.domain.MissionStatus;
 import swm.hkcc.LGTM.app.modules.registration.domain.MissionRegistration;
-import swm.hkcc.LGTM.app.modules.registration.domain.PersonalStatus;
+import swm.hkcc.LGTM.app.modules.registration.domain.ProcessStatus;
 import swm.hkcc.LGTM.app.modules.registration.repository.MissionRegistrationRepository;
 
 import java.time.LocalDate;
@@ -109,13 +109,13 @@ class MissionCustomRepositoryImplTest {
     void getOnGoingMissions() {
         // Given
         MissionRegistration registration1 = MissionRegistration.builder()
-                .status(PersonalStatus.WAITING_FOR_PAYMENT)
+                .status(ProcessStatus.WAITING_FOR_PAYMENT)
                 .mission(mission1)
                 .junior(member)
                 .build();
 
         MissionRegistration registration3 = MissionRegistration.builder()
-                .status(PersonalStatus.MISSION_PROCEEDING)
+                .status(ProcessStatus.MISSION_PROCEEDING)
                 .mission(mission3)
                 .junior(member)
                 .build();

--- a/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/registration/controller/RegistrationMissionControllerTest.java
+++ b/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/registration/controller/RegistrationMissionControllerTest.java
@@ -1,0 +1,395 @@
+package swm.hkcc.LGTM.app.modules.registration.controller;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import swm.hkcc.LGTM.app.global.constant.ResponseCode;
+import swm.hkcc.LGTM.app.modules.member.domain.Authority;
+import swm.hkcc.LGTM.app.modules.member.domain.Member;
+import swm.hkcc.LGTM.app.modules.member.domain.custom.CustomUserDetails;
+import swm.hkcc.LGTM.app.modules.member.exception.NotJuniorMember;
+import swm.hkcc.LGTM.app.modules.member.repository.MemberRepository;
+import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
+import swm.hkcc.LGTM.app.modules.mission.exception.NotExistMission;
+import swm.hkcc.LGTM.app.modules.registration.domain.ProcessStatus;
+import swm.hkcc.LGTM.app.modules.registration.dto.MemberRegisterSimpleInfo;
+import swm.hkcc.LGTM.app.modules.registration.dto.RegistrationSeniorResponse;
+import swm.hkcc.LGTM.app.modules.registration.exception.AlreadyRegisteredMission;
+import swm.hkcc.LGTM.app.modules.registration.exception.FullRegisterMembers;
+import swm.hkcc.LGTM.app.modules.registration.exception.MissRegisterDeadline;
+import swm.hkcc.LGTM.app.modules.registration.service.RegistrationService;
+import swm.hkcc.LGTM.app.modules.tag.domain.TechTag;
+import swm.hkcc.LGTM.utils.CustomMDGenerator;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static swm.hkcc.LGTM.utils.CustomMDGenerator.tableHead;
+import static swm.hkcc.LGTM.utils.CustomMDGenerator.tableRow;
+
+@Slf4j
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+class RegistrationMissionControllerTest {
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RegistrationService registrationService;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    public void setUp(@Autowired WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentationContextProvider) {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .apply(documentationConfiguration(restDocumentationContextProvider))
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .alwaysDo(print())
+                .build();
+    }
+
+    @Test
+    @DisplayName("미션 등록 동작 테스트")
+    void 미션_등록() throws Exception {
+        // given
+        Mission mission = Mission.builder()
+                .missionId(1L)
+                .build();
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .githubId("test-token-junior")
+                .nickName("test-junior")
+                .build();
+
+        member.setRoles(Collections.singletonList(Authority.builder().name("ROLE_USER").build()));
+        given(memberRepository.findOneByGithubId(Mockito.anyString())).willReturn(java.util.Optional.ofNullable(member));
+
+
+        given(registrationService.registerJunior(member, mission.getMissionId())).willReturn(1L);
+        // when
+        // then
+        ResultActions actions = mockMvc.perform(post("/v1/mission/{missionId}", mission.getMissionId())
+                        .header(
+                                "Authorization",
+                                // todo : mock member로부터 토큰 생성해서 넣기
+                                "Bearer eyJhbGciOiJIUzI1NiJ9.eyJnaXRodWJJZCI6InRlc3QtdG9rZW4tc2VuaW9yIiwiaWF0IjoxNjkwNTAyNzI0LCJleHAiOjE3ODUxMTA3MjR9.gKBXkTs-71pdu6wGE3_aP5oSXaAeO8tkN-tYi_mB0es"
+                        )
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.responseCode").value(0))
+                .andExpect(jsonPath("$.message").value("Ok"))
+                .andExpect(jsonPath("$.data").value(true));
+
+        // document
+        actions.andDo(document(
+                "register-junior",  // 문서의 고유 id
+                preprocessRequest(prettyPrint()),        // request JSON 정렬하여 출력
+                preprocessResponse(prettyPrint()),       // response JSON 정렬하여 출력
+                resource(ResourceSnippetParameters.builder()
+                        .summary("[미션] 주니어 미션 참가")
+                        .tag("미션")
+                        .description(CustomMDGenerator.builder()
+                                .h1("[Descriptions]")
+                                .h3("주니어가 미션에 참가한다.")
+                                .h1("[Request Headers]")
+                                .table(
+                                        tableHead("Request values", "Data Type", "Description"),
+                                        //Authorization
+                                        tableRow("Authorization", "String", "액세스 토큰")
+                                )
+                                .h1("[Path Variables]")
+                                .table(
+                                        tableHead("Request values", "Data Type", "Description"),
+                                        tableRow("missionId", "Long", "미션 아이디")
+                                )
+                                .line()
+                                .h1("[Errors]")
+                                .table(
+                                        tableHead("HTTP Status", "Response Code", "Message"),
+                                        tableRow(
+                                                ResponseCode.NOT_JUNIOR_MEMBER.getHttpStatus().toString(),
+                                                ResponseCode.NOT_JUNIOR_MEMBER.getCode().toString(),
+                                                ResponseCode.NOT_JUNIOR_MEMBER.getMessage()
+                                        ),
+                                        tableRow(
+                                                ResponseCode.NOT_EXIST_MISSION.getHttpStatus().toString(),
+                                                ResponseCode.NOT_EXIST_MISSION.getCode().toString(),
+                                                ResponseCode.NOT_EXIST_MISSION.getMessage()
+                                        ),
+                                        tableRow(
+                                                ResponseCode.ALREADY_REGISTERED_MISSION.getHttpStatus().toString(),
+                                                ResponseCode.ALREADY_REGISTERED_MISSION.getCode().toString(),
+                                                ResponseCode.ALREADY_REGISTERED_MISSION.getMessage()
+                                        ),
+                                        tableRow(
+                                                ResponseCode.MISS_REGISTER_DEADLINE.getHttpStatus().toString(),
+                                                ResponseCode.MISS_REGISTER_DEADLINE.getCode().toString(),
+                                                ResponseCode.MISS_REGISTER_DEADLINE.getMessage()
+                                        ),
+                                        tableRow(
+                                                ResponseCode.FULL_REGISTER_MEMBERS.getHttpStatus().toString(),
+                                                ResponseCode.FULL_REGISTER_MEMBERS.getCode().toString(),
+                                                ResponseCode.FULL_REGISTER_MEMBERS.getMessage()
+                                        )
+                                )
+                                .build())
+                        .requestHeaders(headerWithName("Authorization").description("access token"))
+                        .pathParameters(parameterWithName("missionId").type(SimpleType.NUMBER).description("미션 아이디"))
+                        .responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("responseCode").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data").type(JsonFieldType.BOOLEAN).description("응답 데이터")
+                        )
+                        .build())));
+    }
+
+    @Test
+    @DisplayName("미션 등록 실패 테스트 - 주니어 아님")
+    void 미션_등록_실패_주니어_아님() throws Exception {
+        // given
+        Mission mission = Mission.builder()
+                .missionId(1L)
+                .build();
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .githubId("test-token-junior")
+                .nickName("test-junior")
+                .build();
+
+        member.setRoles(Collections.singletonList(Authority.builder().name("ROLE_USER").build()));
+        given(memberRepository.findOneByGithubId(Mockito.anyString())).willReturn(Optional.ofNullable(member));
+
+
+        given(registrationService.registerJunior(member, mission.getMissionId())).willThrow(new NotJuniorMember());
+
+        // when
+        // then
+        ResponseCode expectedResponseCode = ResponseCode.NOT_JUNIOR_MEMBER;
+        ResultActions actions = mockMvc.perform(post("/v1/mission/{missionId}", mission.getMissionId())
+                        .header(
+                                "Authorization",
+                                // todo : mock member로부터 토큰 생성해서 넣기
+                                "Bearer eyJhbGciOiJIUzI1NiJ9.eyJnaXRodWJJZCI6InRlc3QtdG9rZW4tc2VuaW9yIiwiaWF0IjoxNjkwNTAyNzI0LCJleHAiOjE3ODUxMTA3MjR9.gKBXkTs-71pdu6wGE3_aP5oSXaAeO8tkN-tYi_mB0es"
+                        )
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is(expectedResponseCode.getHttpStatus().value()))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.responseCode").value(expectedResponseCode.getCode()))
+                .andExpect(jsonPath("$.message").value(expectedResponseCode.getMessage()));
+
+        // document
+        actions.andDo(document(
+                "register-junior-not-junior",  // 문서의 고유 id
+                preprocessRequest(prettyPrint()),        // request JSON 정렬하여 출력
+                preprocessResponse(prettyPrint())));      // response JSON 정렬하여 출력
+    }
+
+    @Test
+    @DisplayName("미션 등록 실패 테스트 - 미션 없음")
+    void 미션_등록_실패_미션_없음() throws Exception {
+        // given
+        Mission mission = Mission.builder()
+                .missionId(1L)
+                .build();
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .githubId("test-token-junior")
+                .nickName("test-junior")
+                .build();
+
+        member.setRoles(Collections.singletonList(Authority.builder().name("ROLE_USER").build()));
+        given(memberRepository.findOneByGithubId(Mockito.anyString())).willReturn(Optional.ofNullable(member));
+
+
+        given(registrationService.registerJunior(member, mission.getMissionId())).willThrow(new NotExistMission());
+
+        // when
+        // then
+        ResponseCode expectedResponseCode = ResponseCode.NOT_EXIST_MISSION;
+        ResultActions actions = mockMvc.perform(post("/v1/mission/{missionId}", mission.getMissionId())
+                        .header(
+                                "Authorization",
+                                // todo : mock member로부터 토큰 생성해서 넣기
+                                "Bearer eyJhbGciOiJIUzI1NiJ9.eyJnaXRodWJJZCI6InRlc3QtdG9rZW4tc2VuaW9yIiwiaWF0IjoxNjkwNTAyNzI0LCJleHAiOjE3ODUxMTA3MjR9.gKBXkTs-71pdu6wGE3_aP5oSXaAeO8tkN-tYi_mB0es"
+                        )
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is(expectedResponseCode.getHttpStatus().value()))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.responseCode").value(expectedResponseCode.getCode()))
+                .andExpect(jsonPath("$.message").value(expectedResponseCode.getMessage()));
+
+        // document
+        actions.andDo(document(
+                "register-junior-not-exist-mission",  // 문서의 고유 id
+                preprocessRequest(prettyPrint()),        // request JSON 정렬하여 출력
+                preprocessResponse(prettyPrint())));      // response JSON 정렬하여 출력
+    }
+
+    @Test
+    @DisplayName("미션 등록 실패 테스트 - 이미등록한 미션")
+    void 미션_등록_실패_ALREADY_REGISTERED_MISSION() throws Exception {
+        // given
+        Mission mission = Mission.builder()
+                .missionId(1L)
+                .build();
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .githubId("test-token-junior")
+                .nickName("test-junior")
+                .build();
+
+        member.setRoles(Collections.singletonList(Authority.builder().name("ROLE_USER").build()));
+        given(memberRepository.findOneByGithubId(Mockito.anyString())).willReturn(Optional.ofNullable(member));
+
+        given(registrationService.registerJunior(member, mission.getMissionId())).willThrow(new AlreadyRegisteredMission());
+
+        // when
+        // then
+        ResponseCode expectedResponseCode = ResponseCode.ALREADY_REGISTERED_MISSION;
+        ResultActions actions = mockMvc.perform(post("/v1/mission/{missionId}", mission.getMissionId())
+                        .header(
+                                "Authorization",
+                                // todo : mock member로부터 토큰 생성해서 넣기
+                                "Bearer eyJhbGciOiJIUzI1NiJ9.eyJnaXRodWJJZCI6InRlc3QtdG9rZW4tc2VuaW9yIiwiaWF0IjoxNjkwNTAyNzI0LCJleHAiOjE3ODUxMTA3MjR9.gKBXkTs-71pdu6wGE3_aP5oSXaAeO8tkN-tYi_mB0es"
+                        )
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is(expectedResponseCode.getHttpStatus().value()))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.responseCode").value(expectedResponseCode.getCode()))
+                .andExpect(jsonPath("$.message").value(expectedResponseCode.getMessage()));
+
+        // document
+        actions.andDo(document(
+                "register-junior-already-registered-mission",  // 문서의 고유 id
+                preprocessRequest(prettyPrint()),        // request JSON 정렬하여 출력
+                preprocessResponse(prettyPrint())));      // response JSON 정렬하여 출력
+    }
+
+    @Test
+    @DisplayName("미션 등록 실패 테스트 - 마감기한 지남")
+    void 미션_등록_실패_MISS_REGISTER_DEADLINE() throws Exception {
+
+        // given
+        Mission mission = Mission.builder()
+                .missionId(1L)
+                .build();
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .githubId("test-token-junior")
+                .nickName("test-junior")
+                .build();
+
+        member.setRoles(Collections.singletonList(Authority.builder().name("ROLE_USER").build()));
+        given(memberRepository.findOneByGithubId(Mockito.anyString())).willReturn(Optional.ofNullable(member));
+
+        given(registrationService.registerJunior(member, mission.getMissionId())).willThrow(new MissRegisterDeadline());
+
+        // when
+        // then
+        ResponseCode expectedResponseCode = ResponseCode.MISS_REGISTER_DEADLINE;
+        ResultActions actions = mockMvc.perform(post("/v1/mission/{missionId}", mission.getMissionId())
+                        .header(
+                                "Authorization",
+                                // todo : mock member로부터 토큰 생성해서 넣기
+                                "Bearer eyJhbGciOiJIUzI1NiJ9.eyJnaXRodWJJZCI6InRlc3QtdG9rZW4tc2VuaW9yIiwiaWF0IjoxNjkwNTAyNzI0LCJleHAiOjE3ODUxMTA3MjR9.gKBXkTs-71pdu6wGE3_aP5oSXaAeO8tkN-tYi_mB0es"
+                        )
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is(expectedResponseCode.getHttpStatus().value()))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.responseCode").value(expectedResponseCode.getCode()))
+                .andExpect(jsonPath("$.message").value(expectedResponseCode.getMessage()));
+
+        // document
+        actions.andDo(document(
+                "register-junior-miss-register-deadline",  // 문서의 고유 id
+                preprocessRequest(prettyPrint()),        // request JSON 정렬하여 출력
+                preprocessResponse(prettyPrint())));      // response JSON 정렬하여 출력
+    }
+
+    @Test
+    @DisplayName("미션 등록 실패 테스트 - 미션 참가 인원 초과")
+    void 미션_등록_실패_FULL_REGISTER_MEMBERS() throws Exception {
+
+        // given
+        Mission mission = Mission.builder()
+                .missionId(1L)
+                .build();
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .githubId("test-token-junior")
+                .nickName("test-junior")
+                .build();
+
+        member.setRoles(Collections.singletonList(Authority.builder().name("ROLE_USER").build()));
+        given(memberRepository.findOneByGithubId(Mockito.anyString())).willReturn(Optional.ofNullable(member));
+
+        given(registrationService.registerJunior(member, mission.getMissionId())).willThrow(new FullRegisterMembers());
+
+        // when
+        // then
+        ResponseCode expectedResponseCode = ResponseCode.FULL_REGISTER_MEMBERS;
+        ResultActions actions = mockMvc.perform(post("/v1/mission/{missionId}", mission.getMissionId())
+                        .header(
+                                "Authorization",
+                                // todo : mock member로부터 토큰 생성해서 넣기
+                                "Bearer eyJhbGciOiJIUzI1NiJ9.eyJnaXRodWJJZCI6InRlc3QtdG9rZW4tc2VuaW9yIiwiaWF0IjoxNjkwNTAyNzI0LCJleHAiOjE3ODUxMTA3MjR9.gKBXkTs-71pdu6wGE3_aP5oSXaAeO8tkN-tYi_mB0es"
+                        )
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is(expectedResponseCode.getHttpStatus().value()))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.responseCode").value(expectedResponseCode.getCode()))
+                .andExpect(jsonPath("$.message").value(expectedResponseCode.getMessage()));
+
+        // document
+        actions.andDo(document(
+                "register-junior-full-register-members",  // 문서의 고유 id
+                preprocessRequest(prettyPrint()),        // request JSON 정렬하여 출력
+                preprocessResponse(prettyPrint())));      // response JSON 정렬하여 출력
+    }
+}

--- a/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/registration/controller/SeniorDashboardControllerTest.java
+++ b/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/registration/controller/SeniorDashboardControllerTest.java
@@ -37,6 +37,7 @@ import swm.hkcc.LGTM.app.modules.registration.dto.RegistrationSeniorResponse;
 import swm.hkcc.LGTM.app.modules.registration.exception.NotMyMission;
 import swm.hkcc.LGTM.app.modules.registration.service.RegistrationService;
 import swm.hkcc.LGTM.app.modules.tag.domain.TechTag;
+import swm.hkcc.LGTM.utils.CustomMDGenerator;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -53,6 +54,8 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static swm.hkcc.LGTM.utils.CustomMDGenerator.tableHead;
+import static swm.hkcc.LGTM.utils.CustomMDGenerator.tableRow;
 
 @Slf4j
 @SpringBootTest
@@ -150,7 +153,41 @@ class SeniorDashboardControllerTest {
                 resource(ResourceSnippetParameters.builder()
                         .summary("[미션 진행] 시니어 미션 참가자 조회")
                         .tag("미션 진행")
-                        .description("")
+                        .description(CustomMDGenerator.builder()
+                                .h1("[Descriptions]")
+                                .h3("시니어가 가 자신의 미션 참가자 정보를 조회한다.")
+                                .h1("[Request Headers]")
+                                .table(
+                                        tableHead("Request values", "Data Type", "Description"),
+                                        //Authorization
+                                        tableRow("Authorization", "String", "액세스 토큰")
+                                )
+                                .h1("[Path Variables]")
+                                .table(
+                                        tableHead("Request values", "Data Type", "Description"),
+                                        tableRow("missionId", "Long", "미션 아이디")
+                                )
+                                .line()
+                                .h1("[Errors]")
+                                .table(
+                                        tableHead("HTTP Status", "Response Code", "Message"),
+                                        tableRow(
+                                                ResponseCode.NOT_SENIOR_MEMBER.getHttpStatus().toString(),
+                                                ResponseCode.NOT_SENIOR_MEMBER.getCode().toString(),
+                                                ResponseCode.NOT_SENIOR_MEMBER.getMessage()
+                                        ),
+                                        tableRow(
+                                                ResponseCode.NOT_EXIST_MISSION.getHttpStatus().toString(),
+                                                ResponseCode.NOT_EXIST_MISSION.getCode().toString(),
+                                                ResponseCode.NOT_EXIST_MISSION.getMessage()
+                                        ),
+                                        tableRow(
+                                                ResponseCode.NOT_MY_MISSION.getHttpStatus().toString(),
+                                                ResponseCode.NOT_MY_MISSION.getCode().toString(),
+                                                ResponseCode.NOT_MY_MISSION.getMessage()
+                                        )
+                                )
+                                .build())
                         .requestHeaders(headerWithName("Authorization").description("access token"))
                         .pathParameters(parameterWithName("missionId").type(SimpleType.NUMBER).description("미션 아이디"))
                         .responseFields(

--- a/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/registration/controller/SeniorDashboardControllerTest.java
+++ b/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/registration/controller/SeniorDashboardControllerTest.java
@@ -1,0 +1,298 @@
+package swm.hkcc.LGTM.app.modules.registration.controller;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import swm.hkcc.LGTM.app.global.constant.ResponseCode;
+import swm.hkcc.LGTM.app.modules.member.domain.Authority;
+import swm.hkcc.LGTM.app.modules.member.domain.Member;
+import swm.hkcc.LGTM.app.modules.member.domain.custom.CustomUserDetails;
+import swm.hkcc.LGTM.app.modules.member.exception.NotSeniorMember;
+import swm.hkcc.LGTM.app.modules.member.repository.MemberRepository;
+import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
+import swm.hkcc.LGTM.app.modules.mission.exception.NotExistMission;
+import swm.hkcc.LGTM.app.modules.registration.domain.ProcessStatus;
+import swm.hkcc.LGTM.app.modules.registration.dto.MemberRegisterSimpleInfo;
+import swm.hkcc.LGTM.app.modules.registration.dto.RegistrationSeniorResponse;
+import swm.hkcc.LGTM.app.modules.registration.exception.NotMyMission;
+import swm.hkcc.LGTM.app.modules.registration.service.RegistrationService;
+import swm.hkcc.LGTM.app.modules.tag.domain.TechTag;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Slf4j
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+class SeniorDashboardControllerTest {
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RegistrationService registrationService;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private CustomUserDetails customUserDetails;
+
+    private RegistrationController registrationController;
+
+    @BeforeEach
+    public void setUp(@Autowired WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentationContextProvider) {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .apply(documentationConfiguration(restDocumentationContextProvider))
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .alwaysDo(print())
+                .build();
+    }
+
+    @Test
+    @DisplayName("시니어 미션 참가자 조회 동작 테스트")
+    void 시니어_미션_참가자_조회() throws Exception {
+        // given
+        Mission mission = Mission.builder()
+                .missionId(1L)
+                .build();
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .githubId("test-token-senior")
+                .nickName("test-senior")
+                .build();
+
+        member.setRoles(Collections.singletonList(Authority.builder().name("ROLE_USER").build()));
+        given(memberRepository.findOneByGithubId(Mockito.anyString())).willReturn(java.util.Optional.ofNullable(member));
+
+
+        // Setup mockResponse with the sample data
+        List<TechTag> techTags = Arrays.asList(
+                new TechTag(7L, "Android"),
+                new TechTag(12L, "Kotlin"),
+                new TechTag(13L, "iOS")
+        );
+
+        MemberRegisterSimpleInfo memberInfo = new MemberRegisterSimpleInfo();
+        memberInfo.setMemberId(114L);
+        memberInfo.setNickname("1호선 광인");
+        memberInfo.setGithubId("No.1_crazier");
+        memberInfo.setProfileImageUrl("https://loremflickr.com/cache/resized/65535_52449252296_9a9872253f_c_460_460_nofilter.jpg");
+        memberInfo.setProcessStatus(ProcessStatus.WAITING_FOR_PAYMENT);
+        memberInfo.setPaymentDate(null);
+        memberInfo.setMissionFinishedDate(null);
+        memberInfo.setGithubPrUrl("");
+
+        RegistrationSeniorResponse mockResponse = RegistrationSeniorResponse.builder()
+                .missionName("당근마켓 리드가 직접 알려주는 당근마켓 인프라 찍먹하기")
+                .techTagList(techTags)
+                .memberInfoList(Arrays.asList(memberInfo))
+                .build();
+
+        given(registrationService.getSeniorEnrollInfo(member, mission.getMissionId())).willReturn(mockResponse);
+        // when
+        // then
+        ResultActions actions = mockMvc.perform(get("/v1/mission/{missionId}/senior", mission.getMissionId())
+                        .header(
+                                "Authorization",
+                                // todo : mock member로부터 토큰 생성해서 넣기
+                                "Bearer eyJhbGciOiJIUzI1NiJ9.eyJnaXRodWJJZCI6InRlc3QtdG9rZW4tc2VuaW9yIiwiaWF0IjoxNjkwNTAyNzI0LCJleHAiOjE3ODUxMTA3MjR9.gKBXkTs-71pdu6wGE3_aP5oSXaAeO8tkN-tYi_mB0es"
+                        )
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.responseCode").value(0))
+                .andExpect(jsonPath("$.message").value("Ok"))
+                .andExpect(jsonPath("$.data.missionName").value("당근마켓 리드가 직접 알려주는 당근마켓 인프라 찍먹하기"))
+                .andExpect(jsonPath("$.data.techTagList[0].techTagId").value(7))
+                .andExpect(jsonPath("$.data.techTagList[0].name").value("Android"));
+
+        // document
+        actions.andDo(document(
+                "get-senior-dashboard",  // 문서의 고유 id
+                preprocessRequest(prettyPrint()),        // request JSON 정렬하여 출력
+                preprocessResponse(prettyPrint()),       // response JSON 정렬하여 출력
+                resource(ResourceSnippetParameters.builder()
+                        .summary("[미션 진행] 시니어 미션 참가자 조회")
+                        .tag("미션 진행")
+                        .description("")
+                        .requestHeaders(headerWithName("Authorization").description("access token"))
+                        .pathParameters(parameterWithName("missionId").type(SimpleType.NUMBER).description("미션 아이디"))
+                        .responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                fieldWithPath("responseCode").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                                fieldWithPath("data.missionName").type(JsonFieldType.STRING).description("미션 이름"),
+                                fieldWithPath("data.techTagList").type(JsonFieldType.ARRAY).description("미션 기술 태그 리스트"),
+                                fieldWithPath("data.techTagList[].techTagId").type(JsonFieldType.NUMBER).description("기술 태그 아이디"),
+                                fieldWithPath("data.techTagList[].name").type(JsonFieldType.STRING).description("기술 태그 이름"),
+                                fieldWithPath("data.memberInfoList").type(JsonFieldType.ARRAY).description("미션 참가자 리스트"),
+                                fieldWithPath("data.memberInfoList[].memberId").type(JsonFieldType.NUMBER).description("회원 아이디"),
+                                fieldWithPath("data.memberInfoList[].nickname").type(JsonFieldType.STRING).description("회원 닉네임"),
+                                fieldWithPath("data.memberInfoList[].githubId").type(JsonFieldType.STRING).description("회원 깃허브 아이디"),
+                                fieldWithPath("data.memberInfoList[].profileImageUrl").type(JsonFieldType.STRING).description("회원 프로필 이미지 URL"),
+                                fieldWithPath("data.memberInfoList[].processStatus").type(JsonFieldType.STRING).description("회원 미션 참가 상태"),
+                                fieldWithPath("data.memberInfoList[].paymentDate").type(JsonFieldType.STRING).description("회원 미션 참가 결제일"),
+                                fieldWithPath("data.memberInfoList[].missionFinishedDate").type(JsonFieldType.STRING).description("회원 미션 완료일"),
+                                fieldWithPath("data.memberInfoList[].githubPrUrl").type(JsonFieldType.STRING).description("회원 미션 PR URL")
+                        )
+                        .build())));
+    }
+
+    @Test
+    @DisplayName("시니어 미션 참가자 조회 실패 테스트 - 시니어가 아닌 경우")
+    void 시니어_미션_참가자_조회_실패_시니어가_아님() throws Exception {
+        // given
+        Mission mission = Mission.builder()
+                .missionId(1L)
+                .build();
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .build();
+        member.setRoles(Collections.singletonList(Authority.builder().name("ROLE_USER").build()));
+        given(memberRepository.findOneByGithubId(Mockito.anyString())).willReturn(java.util.Optional.ofNullable(member));
+
+
+        given(registrationService.getSeniorEnrollInfo(member, mission.getMissionId())).willThrow(new NotSeniorMember());
+        // when
+
+        // then
+        ResponseCode expectedResponseCode = ResponseCode.NOT_SENIOR_MEMBER;
+
+        ResultActions actions = mockMvc.perform(get("/v1/mission/{missionId}/senior", mission.getMissionId())
+                        .header(
+                                "Authorization",
+                                // todo : mock member로부터 토큰 생성해서 넣기
+                                "Bearer eyJhbGciOiJIUzI1NiJ9.eyJnaXRodWJJZCI6InRlc3QtdG9rZW4tc2VuaW9yIiwiaWF0IjoxNjkwNTAyNzI0LCJleHAiOjE3ODUxMTA3MjR9.gKBXkTs-71pdu6wGE3_aP5oSXaAeO8tkN-tYi_mB0es"
+                        )
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.responseCode").value(expectedResponseCode.getCode()))
+                .andExpect(jsonPath("$.message").value(expectedResponseCode.getMessage()));
+
+        // document
+        actions.andDo(document(
+                "get-senior-dashboard-fail-not-senior",  // 문서의 고유 id
+                preprocessRequest(prettyPrint()),        // request JSON 정렬하여 출력
+                preprocessResponse(prettyPrint())));       // response JSON 정렬하여 출력
+    }
+
+    @Test
+    @DisplayName("시니어 미션 참가자 조회 실패 테스트 - 미션이 없는 경우")
+    void 시니어_미션_참가자_조회_실패_미션_없음() throws Exception {
+        // given
+        Mission mission = Mission.builder()
+                .missionId(1L)
+                .build();
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .build();
+        member.setRoles(Collections.singletonList(Authority.builder().name("ROLE_USER").build()));
+        given(memberRepository.findOneByGithubId(Mockito.anyString())).willReturn(java.util.Optional.ofNullable(member));
+
+
+        given(registrationService.getSeniorEnrollInfo(member, mission.getMissionId())).willThrow(new NotExistMission());
+        // when
+
+        // then
+        ResponseCode expectedResponseCode = ResponseCode.NOT_EXIST_MISSION;
+
+        ResultActions actions = mockMvc.perform(get("/v1/mission/{missionId}/senior", mission.getMissionId())
+                        .header(
+                                "Authorization",
+                                // todo : mock member로부터 토큰 생성해서 넣기
+                                "Bearer eyJhbGciOiJIUzI1NiJ9.eyJnaXRodWJJZCI6InRlc3QtdG9rZW4tc2VuaW9yIiwiaWF0IjoxNjkwNTAyNzI0LCJleHAiOjE3ODUxMTA3MjR9.gKBXkTs-71pdu6wGE3_aP5oSXaAeO8tkN-tYi_mB0es"
+                        )
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.responseCode").value(expectedResponseCode.getCode()))
+                .andExpect(jsonPath("$.message").value(expectedResponseCode.getMessage()));
+
+        // document
+        actions.andDo(document(
+                "get-senior-dashboard-not-exist-mission",  // 문서의 고유 id
+                preprocessRequest(prettyPrint()),        // request JSON 정렬하여 출력
+                preprocessResponse(prettyPrint())));       // response JSON 정렬하여 출력
+    }
+
+    @Test
+    @DisplayName("시니어 미션 참가자 조회 실패 테스트 - 자신의 미션이 아닌 경우")
+    void 시니어_미션_참가자_조회_실패_자신의_미션이_아님() throws Exception {
+        // given
+        Mission mission = Mission.builder()
+                .missionId(1L)
+                .build();
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .build();
+        member.setRoles(Collections.singletonList(Authority.builder().name("ROLE_USER").build()));
+        given(memberRepository.findOneByGithubId(Mockito.anyString())).willReturn(java.util.Optional.ofNullable(member));
+
+
+        given(registrationService.getSeniorEnrollInfo(member, mission.getMissionId())).willThrow(new NotMyMission());
+        // when
+
+        // then
+        ResponseCode expectedResponseCode = ResponseCode.NOT_MY_MISSION;
+
+        ResultActions actions = mockMvc.perform(get("/v1/mission/{missionId}/senior", mission.getMissionId())
+                        .header(
+                                "Authorization",
+                                // todo : mock member로부터 토큰 생성해서 넣기
+                                "Bearer eyJhbGciOiJIUzI1NiJ9.eyJnaXRodWJJZCI6InRlc3QtdG9rZW4tc2VuaW9yIiwiaWF0IjoxNjkwNTAyNzI0LCJleHAiOjE3ODUxMTA3MjR9.gKBXkTs-71pdu6wGE3_aP5oSXaAeO8tkN-tYi_mB0es"
+                        )
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.responseCode").value(expectedResponseCode.getCode()))
+                .andExpect(jsonPath("$.message").value(expectedResponseCode.getMessage()));
+
+        // document
+        actions.andDo(document(
+                "get-senior-dashboard-fail-not-my-mission",  // 문서의 고유 id
+                preprocessRequest(prettyPrint()),        // request JSON 정렬하여 출력
+                preprocessResponse(prettyPrint())));       // response JSON 정렬하여 출력
+    }
+
+}

--- a/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/registration/controller/SeniorDashboardControllerTest.java
+++ b/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/registration/controller/SeniorDashboardControllerTest.java
@@ -26,7 +26,6 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 import swm.hkcc.LGTM.app.global.constant.ResponseCode;
 import swm.hkcc.LGTM.app.modules.member.domain.Authority;
 import swm.hkcc.LGTM.app.modules.member.domain.Member;
-import swm.hkcc.LGTM.app.modules.member.domain.custom.CustomUserDetails;
 import swm.hkcc.LGTM.app.modules.member.exception.NotSeniorMember;
 import swm.hkcc.LGTM.app.modules.member.repository.MemberRepository;
 import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
@@ -70,11 +69,6 @@ class SeniorDashboardControllerTest {
 
     @MockBean
     private MemberRepository memberRepository;
-
-    @MockBean
-    private CustomUserDetails customUserDetails;
-
-    private RegistrationController registrationController;
 
     @BeforeEach
     public void setUp(@Autowired WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentationContextProvider) {

--- a/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationServiceTest.java
+++ b/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationServiceTest.java
@@ -10,6 +10,7 @@ import swm.hkcc.LGTM.app.modules.member.domain.Member;
 import swm.hkcc.LGTM.app.modules.member.domain.Senior;
 import swm.hkcc.LGTM.app.modules.member.exception.NotJuniorMember;
 import swm.hkcc.LGTM.app.modules.member.exception.NotSeniorMember;
+import swm.hkcc.LGTM.app.modules.member.service.MemberValidator;
 import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
 import swm.hkcc.LGTM.app.modules.mission.exception.NotExistMission;
 import swm.hkcc.LGTM.app.modules.mission.repository.MissionRepository;
@@ -32,25 +33,18 @@ class RegistrationServiceTest {
     @Mock
     private MissionRegistrationRepository missionRegistrationRepository;
 
+    @Mock
+    private MemberValidator memberValidator;
+
+    @Mock
+    private RegistrationValidator registrationValidator;
+
     @InjectMocks
     private RegistrationService registrationService;
 
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-    }
-
-    @Test
-    void Register_junior가_아닌_경우() {
-        // given
-        Member notJunior = Member.builder()
-                .memberId(1L)
-                .build();
-        // when
-
-        // then
-        assertThatThrownBy(() -> registrationService.registerJunior(notJunior, 1L))
-                .isInstanceOf(NotJuniorMember.class);
     }
 
     @Test
@@ -70,68 +64,6 @@ class RegistrationServiceTest {
                 .isInstanceOf(NotExistMission.class);
     }
 
-    // 미션 마감일이 지난 경우
-    @Test
-    void Register_미션_마감일이_지난_경우() {
-        // given
-        Member junior = Member.builder()
-                .memberId(1L)
-                .junior(Junior.builder()
-                        .juniorId(1L)
-                        .build())
-                .build();
-        Mission mission = Mission.builder()
-                .missionId(1L)
-                .registrationDueDate(LocalDate.now().minusDays(1))
-                .build();
-        given(missionRepository.findById(1L)).willReturn(Optional.of(mission));
-        given(missionRegistrationRepository.countByMission_MissionId(1L)).willReturn(10);
-
-        // when
-
-        // then
-        assertThatThrownBy(() -> registrationService.registerJunior(junior, mission.getMissionId()))
-                .isInstanceOf(MissRegisterDeadline.class);
-    }
-
-    @Test
-    void Register_미션_등록인원이_넘치는_경우() {
-        // given
-        Member junior = Member.builder()
-                .memberId(1L)
-                .junior(Junior.builder()
-                        .juniorId(1L)
-                        .build())
-                .build();
-        Mission mission = Mission.builder()
-                .missionId(1L)
-                .registrationDueDate(LocalDate.now().plusDays(1))
-                .maxPeopleNumber(10)
-                .build();
-        given(missionRepository.findById(1L)).willReturn(Optional.of(mission));
-        given(missionRegistrationRepository.countByMission_MissionId(1L)).willReturn(10);
-
-
-        // when
-
-        // then
-        assertThatThrownBy(() -> registrationService.registerJunior(junior, mission.getMissionId()))
-                .isInstanceOf(FullRegisterMembers.class);
-    }
-
-    @Test
-    void Senior_Info_Senior가_아닌_경우() {
-        // given
-        Member notSenior = Member.builder()
-                .memberId(1L)
-                .build();
-        // when
-
-        // then
-        assertThatThrownBy(() -> registrationService.getSeniorEnrollInfo(notSenior, 1L))
-                .isInstanceOf(NotSeniorMember.class);
-    }
-
     @Test
     void Senior_Info_미션_없는_경우() {
         // given
@@ -149,28 +81,4 @@ class RegistrationServiceTest {
                 .isInstanceOf(NotExistMission.class);
     }
 
-    @Test
-    void Senior_Info_자신의_미션이_아닌_경우() {
-        // given
-        Member senior = Member.builder()
-                .memberId(1L)
-                .senior(Senior.builder()
-                        .seniorId(1L)
-                        .build())
-                .build();
-        Mission mission = Mission.builder()
-                .missionId(1L)
-                .writer(Member.builder()
-                        .memberId(2L)
-                        .build())
-                .registrationDueDate(LocalDate.now().plusDays(1))
-                .maxPeopleNumber(10)
-                .build();
-
-        given(missionRepository.findById(1L)).willReturn(Optional.ofNullable(mission));
-
-
-        assertThatThrownBy(() -> registrationService.getSeniorEnrollInfo(senior, 1L))
-                .isInstanceOf(NotMyMission.class);
-    }
 }

--- a/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationServiceTest.java
+++ b/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationServiceTest.java
@@ -1,0 +1,120 @@
+package swm.hkcc.LGTM.app.modules.registration.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import swm.hkcc.LGTM.app.modules.member.domain.Junior;
+import swm.hkcc.LGTM.app.modules.member.domain.Member;
+import swm.hkcc.LGTM.app.modules.member.exception.NotJuniorMember;
+import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
+import swm.hkcc.LGTM.app.modules.mission.exception.NotExistMission;
+import swm.hkcc.LGTM.app.modules.mission.repository.MissionRepository;
+import swm.hkcc.LGTM.app.modules.registration.exception.FullRegisterMembers;
+import swm.hkcc.LGTM.app.modules.registration.exception.MissRegisterDeadline;
+import swm.hkcc.LGTM.app.modules.registration.repository.MissionRegistrationRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+
+class RegistrationServiceTest {
+    @Mock
+    private MissionRepository missionRepository;
+
+    @Mock
+    private MissionRegistrationRepository missionRegistrationRepository;
+
+    @InjectMocks
+    private RegistrationService registrationService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void junior가_아닌_경우() {
+        // given
+        Member notJunior = Member.builder()
+                .memberId(1L)
+                .build();
+        // when
+
+        // then
+        assertThatThrownBy(() -> registrationService.registerJunior(notJunior, 1L))
+                .isInstanceOf(NotJuniorMember.class);
+    }
+
+    @Test
+    void mission_이_없는_경우() {
+        // given
+        Member junior = Member.builder()
+                .memberId(1L)
+                .junior(Junior.builder()
+                        .juniorId(1L)
+                        .build())
+                .build();
+        given(missionRepository.findById(1L)).willReturn(Optional.ofNullable(null));
+        // when
+
+        // then
+        assertThatThrownBy(() -> registrationService.registerJunior(junior, 0L))
+                .isInstanceOf(NotExistMission.class);
+    }
+
+    // 미션 마감일이 지난 경우
+    @Test
+    void 미션_마감일이_지난_경우() {
+        // given
+        Member junior = Member.builder()
+                .memberId(1L)
+                .junior(Junior.builder()
+                        .juniorId(1L)
+                        .build())
+                .build();
+        Mission mission = Mission.builder()
+                .missionId(1L)
+                .registrationDueDate(LocalDate.now().minusDays(1))
+                .build();
+        given(missionRepository.findById(1L)).willReturn(Optional.of(mission));
+        given(missionRegistrationRepository.countByMission_MissionId(1L)).willReturn(10);
+
+        // when
+
+        // then
+        assertThatThrownBy(() -> registrationService.registerJunior(junior, mission.getMissionId()))
+                .isInstanceOf(MissRegisterDeadline.class);
+    }
+
+    @Test
+    void 미션_등록인원이_넘치는_경우() {
+        // given
+        Member junior = Member.builder()
+                .memberId(1L)
+                .junior(Junior.builder()
+                        .juniorId(1L)
+                        .build())
+                .build();
+        Mission mission = Mission.builder()
+                .missionId(1L)
+                .registrationDueDate(LocalDate.now().plusDays(1))
+                .maxPeopleNumber(10)
+                .build();
+        given(missionRepository.findById(1L)).willReturn(Optional.of(mission));
+        given(missionRegistrationRepository.countByMission_MissionId(1L)).willReturn(10);
+
+
+        // when
+
+        // then
+        assertThatThrownBy(() -> registrationService.registerJunior(junior, mission.getMissionId()))
+                .isInstanceOf(FullRegisterMembers.class);
+    }
+
+
+}

--- a/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationValidatorTest.java
+++ b/API-Server/src/test/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationValidatorTest.java
@@ -1,0 +1,110 @@
+package swm.hkcc.LGTM.app.modules.registration.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import swm.hkcc.LGTM.app.modules.member.domain.Junior;
+import swm.hkcc.LGTM.app.modules.member.domain.Member;
+import swm.hkcc.LGTM.app.modules.member.domain.Senior;
+import swm.hkcc.LGTM.app.modules.mission.domain.Mission;
+import swm.hkcc.LGTM.app.modules.registration.exception.FullRegisterMembers;
+import swm.hkcc.LGTM.app.modules.registration.exception.MissRegisterDeadline;
+import swm.hkcc.LGTM.app.modules.registration.exception.NotMyMission;
+import swm.hkcc.LGTM.app.modules.registration.repository.MissionRegistrationRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+class RegistrationValidatorTest {
+    @Mock
+    private MissionRegistrationRepository missionRegistrationRepository;
+
+
+    @InjectMocks
+    private RegistrationValidator registrationValidator;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+
+    // 미션 마감일이 지난 경우
+    @Test
+    void Register_미션_마감일이_지난_경우() {
+        // given
+        Member junior = Member.builder()
+                .memberId(1L)
+                .junior(Junior.builder()
+                        .juniorId(1L)
+                        .build())
+                .build();
+        Mission mission = Mission.builder()
+                .missionId(1L)
+                .registrationDueDate(LocalDate.now().minusDays(1))
+                .build();
+        given(missionRegistrationRepository.countByMission_MissionId(1L)).willReturn(10);
+        // when
+
+        // then
+        assertThatThrownBy(() -> registrationValidator.validateToRegisterMission(mission, junior.getMemberId()))
+                .isInstanceOf(MissRegisterDeadline.class);
+    }
+
+
+    @Test
+    void Register_미션_등록인원이_넘치는_경우() {
+        // given
+        Member junior = Member.builder()
+                .memberId(1L)
+                .junior(Junior.builder()
+                        .juniorId(1L)
+                        .build())
+                .build();
+        Mission mission = Mission.builder()
+                .missionId(1L)
+                .registrationDueDate(LocalDate.now().plusDays(1))
+                .maxPeopleNumber(10)
+                .build();
+        given(missionRegistrationRepository.countByMission_MissionId(1L)).willReturn(10);
+
+
+        // when
+
+        // then
+        assertThatThrownBy(() -> registrationValidator.validateToRegisterMission(mission, junior.getMemberId()))
+                .isInstanceOf(FullRegisterMembers.class);
+    }
+
+
+    @Test
+    void Senior_Info_자신의_미션이_아닌_경우() {
+        // given
+        Member senior = Member.builder()
+                .memberId(1L)
+                .senior(Senior.builder()
+                        .seniorId(1L)
+                        .build())
+                .build();
+        Mission mission = Mission.builder()
+                .missionId(1L)
+                .writer(Member.builder()
+                        .memberId(2L)
+                        .build())
+                .registrationDueDate(LocalDate.now().plusDays(1))
+                .maxPeopleNumber(10)
+                .build();
+
+
+
+        assertThatThrownBy(() -> registrationValidator.validateMissionForSenior(mission, senior.getMemberId()))
+                .isInstanceOf(NotMyMission.class);
+    }
+
+}


### PR DESCRIPTION
## 📝요약
- [x] 미션 등록 api를 위한 Controller, Service, Repository를 추가했습니다.
- [x] 미션 참가자의 진행 상태를 나타내는 PersonalStatus를 ProcessStatus로 변경하고, field를 추가했습니다.
- [x] MissionRegistration, MissionHistory 도메인의 컬럼을 추가했습니다.

<br><br>

## 🔥작업 내용 

<br><br>

## 📋참고 사항

<br><br>

## 🎯관련 이슈

- Close #이슈번호

<br><br>
