### PR TITLE
미션 참가인원 -> @CacheEvict 를 사용하여 미션 등록 시마다 인원 정보 캐시 초기화

### DIFF
--- a/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
+++ b/API-Server/src/main/java/swm/hkcc/LGTM/app/modules/registration/service/RegistrationService.java
@@ -3,6 +3,8 @@ package swm.hkcc.LGTM.app.modules.registration.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import swm.hkcc.LGTM.app.modules.member.domain.Member;
@@ -54,7 +56,7 @@ public class RegistrationService {
     private static final int MAX_LOCK_RETRIES = 10;
     private static final int LOCK_RETRY_DELAY_MS = 100;
 
-
+    @CacheEvict(value = "mission_participant_count", key = "#p1.missionId")
     public long registerJunior(Member junior, Mission mission) throws InterruptedException {
         memberValidator.validateJunior(junior);
 


### PR DESCRIPTION
## 📝요약

레디스 캐시로 인해, 미션 참가 후에도 상세페이지의 인원이 변경되지 않는 문제 발생
<img width="200" alt="image" src="https://github.com/hellokitty-coding-club/LGTM-Backend/assets/61899645/13b08de1-ba3c-4467-bce2-27fb69c68cdd">


<br><br>

## 🔥작업 내용 
`@CacheEvict`를 사용하여 캐시 제거

<br><br>

## 📋참고 사항

<br><br>

## 🎯관련 이슈

- Close #이슈번호

<br><br>
